### PR TITLE
Add `xmake` build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /build*
+/vsxmake*
+/.xmake
 CMakeUserPresets.json
 .DS_Store
 vcpkg*

--- a/AddressLibDecoder/xmake.lua
+++ b/AddressLibDecoder/xmake.lua
@@ -1,0 +1,12 @@
+target("AddressLibDecoder")
+    -- set build by default
+    set_default(false)
+
+    -- set build group
+    set_group("tools")
+    
+    -- add packages
+    add_packages("fmt", "rsm-mmio")
+
+    -- add source files
+    add_files("src/**.cpp")

--- a/AddressLibGen/xmake.lua
+++ b/AddressLibGen/xmake.lua
@@ -1,0 +1,12 @@
+target("AddressLibGen")
+    -- set build by default
+    set_default(false)
+
+    -- set build group
+    set_group("tools")
+
+    -- add packages
+    add_packages("robin-hood-hashing", "srell")
+
+    -- add source files
+    add_files("src/**.cpp")

--- a/CommonLibF4/include/F4SE/Impl/PCH.h
+++ b/CommonLibF4/include/F4SE/Impl/PCH.h
@@ -629,7 +629,7 @@ namespace F4SE
 		{
 			const auto cvt = [&](wchar_t* a_dst, std::size_t a_length) {
 				return WinAPI::MultiByteToWideChar(
-					CP_UTF8,
+					WinAPI::CP_UTF8,
 					0,
 					a_in.data(),
 					static_cast<int>(a_in.length()),
@@ -655,7 +655,7 @@ namespace F4SE
 		{
 			const auto cvt = [&](char* a_dst, std::size_t a_length) {
 				return WinAPI::WideCharToMultiByte(
-					CP_UTF8,
+					WinAPI::CP_UTF8,
 					0,
 					a_in.data(),
 					static_cast<int>(a_in.length()),
@@ -767,7 +767,7 @@ namespace F4SE
 				std::uint32_t result = 0;
 				do {
 					buf.resize(buf.size() * 2);
-					result = GetModuleFileName(
+					result = WinAPI::GetModuleFileName(
 						WinAPI::GetCurrentModule(),
 						buf.data(),
 						static_cast<std::uint32_t>(buf.size()));
@@ -793,7 +793,7 @@ namespace F4SE
 #ifdef ENABLE_COMMONLIBF4_TESTING
 				throw std::runtime_error(utf16_to_utf8(caption.empty() ? body.c_str() : caption.c_str())->c_str());
 #else
-				MessageBox(nullptr, body.c_str(), (caption.empty() ? nullptr : caption.c_str()), 0);
+				WinAPI::MessageBox(nullptr, body.c_str(), (caption.empty() ? nullptr : caption.c_str()), 0);
 				WinAPI::TerminateProcess(WinAPI::GetCurrentProcess(), EXIT_FAILURE);
 #endif
 			}

--- a/CommonLibF4/include/F4SE/Impl/WinAPI.h
+++ b/CommonLibF4/include/F4SE/Impl/WinAPI.h
@@ -236,23 +236,3 @@ namespace RE::DirectX
 	};
 	static_assert(sizeof(XMFLOAT4X4) == 0x40);
 }
-
-#define CP_UTF8 ::F4SE::WinAPI::CP_UTF8
-#define IMAGE_SCN_MEM_EXECUTE ::F4SE::WinAPI::IMAGE_SCN_MEM_EXECUTE
-#define IMAGE_SCN_MEM_WRITE ::F4SE::WinAPI::IMAGE_SCN_MEM_WRITE
-#define INVALID_HANDLE_VALUE ::F4SE::WinAPI::INVALID_HANDLE_VALUE
-#define MAX_PATH ::F4SE::WinAPI::MAX_PATH
-#define MEM_COMMIT ::F4SE::WinAPI::MEM_COMMIT
-#define MEM_RESERVE ::F4SE::WinAPI::MEM_RESERVE
-#define MEM_RELEASE ::F4SE::WinAPI::MEM_RELEASE
-#define PAGE_EXECUTE_READWRITE ::F4SE::WinAPI::PAGE_EXECUTE_READWRITE
-
-#define GetEnvironmentVariable ::F4SE::WinAPI::GetEnvironmentVariable
-#define GetFileVersionInfoSize ::F4SE::WinAPI::GetFileVersionInfoSize
-#define GetModuleFileName ::F4SE::WinAPI::GetModuleFileName
-#define VerQueryValue ::F4SE::WinAPI::VerQueryValue
-#define GetFileVersionInfo ::F4SE::WinAPI::GetFileVersionInfo
-#define GetModuleHandle ::F4SE::WinAPI::GetModuleHandle
-#define LoadLibrary ::F4SE::WinAPI::LoadLibrary
-#define MessageBox ::F4SE::WinAPI::MessageBox
-#define OutputDebugString ::F4SE::WinAPI::OutputDebugString

--- a/CommonLibF4/include/F4SE/Trampoline.h
+++ b/CommonLibF4/include/F4SE/Trampoline.h
@@ -82,7 +82,7 @@ namespace F4SE
 
 			set_trampoline(mem, a_size,
 				[](void* a_mem, std::size_t) {
-					WinAPI::VirtualFree(a_mem, 0, (MEM_RELEASE));
+					WinAPI::VirtualFree(a_mem, 0, (WinAPI::MEM_RELEASE));
 				});
 		}
 

--- a/CommonLibF4/include/RE/Bethesda/MemoryManager.h
+++ b/CommonLibF4/include/RE/Bethesda/MemoryManager.h
@@ -112,7 +112,7 @@ namespace RE
 		static_assert(sizeof(FreeTreeNode) == 0x40);
 
 		// NOLINTNEXTLINE(modernize-use-equals-default)
-		~ScrapHeap() override { WinAPI::VirtualFree(baseAddress, 0, (MEM_RELEASE)); }  // 00
+		~ScrapHeap() override { WinAPI::VirtualFree(baseAddress, 0, (WinAPI::MEM_RELEASE)); }  // 00
 
 		// override (IMemoryStore)
 		std::size_t Size(void const* a_mem) const override { return *static_cast<const std::size_t*>(a_mem) & ~(std::size_t{ 3 } << 62); }  // 01

--- a/CommonLibF4/include/REL/Relocation.h
+++ b/CommonLibF4/include/REL/Relocation.h
@@ -354,7 +354,7 @@ namespace REL
 			WinAPI::VirtualProtect(
 				reinterpret_cast<void*>(a_dst),
 				a_count,
-				(PAGE_EXECUTE_READWRITE),
+				(WinAPI::PAGE_EXECUTE_READWRITE),
 				std::addressof(old));
 		if (success != 0) {
 			std::memcpy(reinterpret_cast<void*>(a_dst), a_src, a_count);
@@ -388,7 +388,7 @@ namespace REL
 			WinAPI::VirtualProtect(
 				reinterpret_cast<void*>(a_dst),
 				a_count,
-				(PAGE_EXECUTE_READWRITE),
+				(WinAPI::PAGE_EXECUTE_READWRITE),
 				std::addressof(old));
 		if (success != 0) {
 			std::fill_n(reinterpret_cast<std::uint8_t*>(a_dst), a_count, a_value);
@@ -585,18 +585,18 @@ namespace REL
 	[[nodiscard]] inline std::optional<Version> get_file_version(stl::zwstring a_filename)
 	{
 		std::uint32_t dummy;
-		std::vector<char> buf(GetFileVersionInfoSize(a_filename.data(), std::addressof(dummy)));
+		std::vector<char> buf(WinAPI::GetFileVersionInfoSize(a_filename.data(), std::addressof(dummy)));
 		if (buf.empty()) {
 			return std::nullopt;
 		}
 
-		if (!GetFileVersionInfo(a_filename.data(), 0, static_cast<std::uint32_t>(buf.size()), buf.data())) {
+		if (!WinAPI::GetFileVersionInfo(a_filename.data(), 0, static_cast<std::uint32_t>(buf.size()), buf.data())) {
 			return std::nullopt;
 		}
 
 		void* verBuf{ nullptr };
 		std::uint32_t verLen{ 0 };
-		if (!VerQueryValue(buf.data(), L"\\StringFileInfo\\040904B0\\ProductVersion", std::addressof(verBuf), std::addressof(verLen))) {
+		if (!WinAPI::VerQueryValue(buf.data(), L"\\StringFileInfo\\040904B0\\ProductVersion", std::addressof(verBuf), std::addressof(verLen))) {
 			return std::nullopt;
 		}
 
@@ -869,7 +869,7 @@ namespace REL
 			std::wstring _tempstr;
 			_tempstr.resize(maxSize + 1);
 			std::fill(_tempstr.begin(), _tempstr.end(), '\0');
-			const auto result = GetEnvironmentVariable(
+			const auto result = WinAPI::GetEnvironmentVariable(
 				envVar.data(),
 				_tempstr.data(),
 				static_cast<std::uint32_t>(maxSize));
@@ -884,7 +884,7 @@ namespace REL
 			if (_filename.empty() || _filename.size() != sz) {
 				for (auto runtime : RUNTIMES) {
 					_filename = runtime;
-					moduleHandle = GetModuleHandle(_filename.c_str());
+					moduleHandle = WinAPI::GetModuleHandle(_filename.c_str());
 					if (moduleHandle) {
 						break;
 					}
@@ -907,7 +907,7 @@ namespace REL
 			std::filesystem::path exePath(a_filePath);
 			_filename = exePath.filename().wstring();
 			_filePath = exePath.wstring();
-			_injectedModule = LoadLibrary(_filePath.c_str());
+			_injectedModule = WinAPI::LoadLibrary(_filePath.c_str());
 			if (_injectedModule) {
 				return load(_injectedModule, false);
 			}
@@ -951,7 +951,7 @@ namespace REL
 		void clear();
 
 		static constexpr std::array SEGMENTS{
-			std::make_pair(".text"sv, IMAGE_SCN_MEM_EXECUTE),
+			std::make_pair(".text"sv, WinAPI::IMAGE_SCN_MEM_EXECUTE),
 			std::make_pair(".interpr"sv, static_cast<std::uint32_t>(0)),
 			std::make_pair(".idata"sv, static_cast<std::uint32_t>(0)),
 			std::make_pair(".rdata"sv, static_cast<std::uint32_t>(0)),

--- a/CommonLibF4/xmake.lua
+++ b/CommonLibF4/xmake.lua
@@ -1,0 +1,91 @@
+option("fallout_f4", function()
+    set_default(true)
+    set_description("Enable runtime support for Fallout 4")
+    add_defines("ENABLE_FALLOUT_F4=1")
+end)
+
+option("fallout_vr", function()
+    set_default(true)
+    set_description("Enable runtime support for Fallout 4 VR")
+    add_defines("ENABLE_FALLOUT_VR=1")
+end)
+
+option("f4se_xbyak", function()
+    set_default(false)
+    set_description("Enable trampoline support for Xbyak")
+    add_defines("F4SE_SUPPORT_XBYAK=1")
+end)
+
+target("CommonLibF4")
+    set_kind("static")
+
+    -- add packages
+    add_packages("boost", "fmt", "rapidcsv", "rsm-binary-io", "rsm-mmio", "spdlog", { public = true })
+
+    if has_config("f4se_xbyak") then
+        add_packages("xbyak")
+    end
+
+    -- add options
+    add_options("fallout_f4", "fallout_vr", "f4se_xbyak")
+
+    -- add system links
+    add_syslinks("dbghelp", "version", "user32", "shell32", "ole32", "advapi32")
+
+    -- add source files
+    add_files("src/**.cpp")
+
+    -- add header files
+    add_includedirs("include", { public = true })
+    add_headerfiles(
+        "include/(RE/**.h)",
+        "include/(REL/**.h)",
+        "include/(F4SE/**.h)"
+    )
+
+    -- set precompiled header
+    set_pcxxheader("include/F4SE/Impl/PCH.h")
+
+    -- add defines
+    add_defines("WIN32_LEAN_AND_MEAN", "NOMINMAX", "BOOST_STL_INTERFACES_DISABLE_CONCEPTS")
+
+    -- add flags
+    add_cxxflags("/permissive-", "cl::/Zc:preprocessor", "cl::/external:W0", "cl::/bigobj")
+
+    -- add flags (warnings -> errors)
+    add_cxxflags("cl::/we4715") -- `function` : not all control paths return a value
+
+    -- add flags(disable warnings)
+    add_cxxflags("cl::/wd4005") -- macro redefinition
+    add_cxxflags("cl::/wd4061") -- enumerator `identifier` in switch of enum `enumeration` is not explicitly handled by a case label
+    add_cxxflags("cl::/wd4068") -- unknown pragma 'clang'
+    add_cxxflags("cl::/wd4200") -- nonstandard extension used : zero-sized array in struct/union
+    add_cxxflags("cl::/wd4201") -- nonstandard extension used : nameless struct/union
+    add_cxxflags("cl::/wd4264") -- 'virtual_function' : no override available for virtual member function from base 'class'; function is hidden
+    add_cxxflags("cl::/wd4265") -- 'type': class has virtual functions, but its non-trivial destructor is not virtual; instances of this class may not be destructed correctly
+    add_cxxflags("cl::/wd4266") -- 'function' : no override available for virtual member function from base 'type'; function is hidden
+    add_cxxflags("cl::/wd4324") -- 'struct_name' : structure was padded due to __declspec(align())
+    add_cxxflags("cl::/wd4371") -- 'classname': layout of class may have changed from a previous version of the compiler due to better packing of member 'member'
+    add_cxxflags("cl::/wd4514") -- 'function' : unreferenced inline function has been removed
+    add_cxxflags("cl::/wd4582") -- 'type': constructor is not implicitly called
+    add_cxxflags("cl::/wd4583") -- 'type': destructor is not implicitly called
+    add_cxxflags("cl::/wd4623") -- 'derived class' : default constructor was implicitly defined as deleted because a base class default constructor is inaccessible or deleted
+    add_cxxflags("cl::/wd4625") -- 'derived class' : copy constructor was implicitly defined as deleted because a base class copy constructor is inaccessible or deleted
+    add_cxxflags("cl::/wd4626") -- 'derived class' : assignment operator was implicitly defined as deleted because a base class assignment operator is inaccessible or deleted
+    add_cxxflags("cl::/wd4686") -- 'user-defined type' : possible change in behavior, change in UDT return calling convention
+    add_cxxflags("cl::/wd4710") -- 'function' : function not inlined
+    add_cxxflags("cl::/wd4711") -- function 'function' selected for inline expansion
+    add_cxxflags("cl::/wd4820") -- 'bytes' bytes padding added after construct 'member_name'
+    add_cxxflags("cl::/wd5082") -- second argument to 'va_start' is not the last named parameter
+    add_cxxflags("cl::/wd5026") -- 'type': move constructor was implicitly defined as deleted
+    add_cxxflags("cl::/wd5027") -- 'type': move assignment operator was implicitly defined as deleted
+    add_cxxflags("cl::/wd5045") -- compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
+    add_cxxflags("cl::/wd5053") -- support for 'explicit(<expr>)' in C++17 and earlier is a vendor extension
+    add_cxxflags("cl::/wd5105") -- macro expansion producing 'defined' has undefined behavior (workaround for older msvc bug)
+    add_cxxflags("cl::/wd5204") -- 'type-name': class has virtual functions, but its trivial destructor is not virtual; instances of objects derived from this class may not be destructed correctly
+    add_cxxflags("cl::/wd5220") -- 'member': a non-static data member with a volatile qualified type no longer implies that compiler generated copy / move constructors and copy / move assignment operators are not trivial
+
+    -- add flags (clang)
+    add_cxxflags("clang::-Wno-overloaded-virtual")
+    add_cxxflags("clang::-Wno-delete-non-abstract-non-virtual-dtor")
+    add_cxxflags("clang::-Wno-reinterpret-base-class")

--- a/RTTIDump/xmake.lua
+++ b/RTTIDump/xmake.lua
@@ -1,0 +1,24 @@
+target("RTTIDump")
+    -- set build kind
+    set_kind("shared")
+
+    -- set build by default
+    set_default(false)
+
+    -- set build group
+    set_group("plugins")
+
+    -- add dependencies
+    add_deps("CommonLibF4")
+
+    -- add packages
+    add_packages("robin-hood-hashing", "rsm-binary-io", "spdlog", "srell")
+
+    -- add source files
+    add_files("src/**.cpp")
+
+    -- add header files
+    add_includedirs("src")
+
+    -- set precompiled header
+    set_pcxxheader("src/PCH.h")

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,0 +1,21 @@
+set_xmakever("2.8.1")
+
+-- set project
+set_project("CommonLibF4")
+set_arch("x64")
+set_languages("c++20")
+set_optimize("faster")
+set_warnings("allextra", "error")
+
+-- add rules
+add_rules("mode.debug", "mode.release")
+
+-- require packages
+add_requires("boost", "fmt", "rapidcsv", "robin-hood-hashing", "rsm-binary-io", "rsm-mmio", "srell", "xbyak")
+add_requires("spdlog", { configs = { header_only = false, fmt_external = true } })
+
+-- include subprojects
+includes("CommonLibF4")
+includes("AddressLibDecoder")
+includes("AddressLibGen")
+includes("RTTIDump")


### PR DESCRIPTION
For now only the main library, AddressLibDecoder, AddressLibGen, and RTTIDump have definition files made for compilation. 

By default only the main library is set to compile when running `xmake build`, to compile the others you can either specify the target:
```
xmake build AddressLibDecoder
```
or the group 
```
xmake build -g tools
```
or if you want to build everything
```
xmake build -a
```