### PR TITLE
Remove minor dependencies

### DIFF
--- a/AddressLibGen/CMakeLists.txt
+++ b/AddressLibGen/CMakeLists.txt
@@ -8,12 +8,10 @@ add_project(
 		"src/main.cpp"
 )
 
-find_package(robin_hood REQUIRED CONFIG)
 find_package(srell MODULE REQUIRED)
 
 target_link_libraries(
 	"${PROJECT_NAME}"
 	PRIVATE
-		robin_hood::robin_hood
 		srell::srell
 )

--- a/AddressLibGen/README.md
+++ b/AddressLibGen/README.md
@@ -1,3 +1,2 @@
 ## Build Dependencies
-* [robin-hood-hashing](https://github.com/martinus/robin-hood-hashing)
 * [SRELL](https://www.akenotsuki.com/misc/srell/en/)

--- a/AddressLibGen/src/main.cpp
+++ b/AddressLibGen/src/main.cpp
@@ -16,10 +16,10 @@
 #include <sstream>
 #include <string>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
-#include <robin_hood.h>
 #include <srell.hpp>
 #pragma warning(pop)
 
@@ -145,8 +145,7 @@ using files_t = std::vector<std::tuple<Version, Version, std::filesystem::path>>
 	return results;
 }
 
-using offset_map = robin_hood::unordered_node_map<std::uint64_t, Mapping>;
-//using offset_map = std::unordered_map<std::uint64_t, Mapping>;
+using offset_map = std::unordered_map<std::uint64_t, Mapping>;
 using version_map = std::map<Version, offset_map>;
 
 [[nodiscard]] version_map load_mappings(const files_t& a_files)

--- a/AddressLibGen/xmake.lua
+++ b/AddressLibGen/xmake.lua
@@ -6,7 +6,7 @@ target("AddressLibGen")
     set_group("tools")
 
     -- add packages
-    add_packages("robin-hood-hashing", "srell")
+    add_packages("srell")
 
     -- add source files
     add_files("src/**.cpp")

--- a/RTTIDump/CMakeLists.txt
+++ b/RTTIDump/CMakeLists.txt
@@ -17,8 +17,6 @@ if(NOT TARGET CommonLibF4)
 	add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../CommonLibF4" CommonLibF4)
 endif()
 
-find_package(binary_io REQUIRED CONFIG)
-find_package(robin_hood REQUIRED CONFIG)
 find_package(spdlog REQUIRED CONFIG)
 find_package(srell MODULE REQUIRED)
 
@@ -26,9 +24,7 @@ target_link_libraries(
 	"${PROJECT_NAME}"
 	PUBLIC
 		CommonLibF4::CommonLibF4
-		binary_io::binary_io
 		Dbghelp.lib
-		robin_hood::robin_hood
 		spdlog::spdlog
 		srell::srell
 )

--- a/RTTIDump/README.md
+++ b/RTTIDump/README.md
@@ -1,5 +1,4 @@
 ## Build Dependencies
 * [CommonLibF4](https://github.com/Ryan-rsm-McKenzie/CommonLibF4)
-* [robin-hood-hashing](https://github.com/martinus/robin-hood-hashing)
 * [spdlog](https://github.com/gabime/spdlog)
 * [SRELL](https://www.akenotsuki.com/misc/srell/en/)

--- a/RTTIDump/src/PCH.h
+++ b/RTTIDump/src/PCH.h
@@ -12,10 +12,10 @@
 #include <memory>
 #include <span>
 #include <tuple>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
-#include <robin_hood.h>
 #include <srell.hpp>
 
 #ifdef NDEBUG

--- a/RTTIDump/src/main.cpp
+++ b/RTTIDump/src/main.cpp
@@ -354,7 +354,7 @@ void dump_nirtti()
 		34089,    // bhkWorldM
 	};
 	logger::debug("Dumping NiRTTI...");
-	robin_hood::unordered_flat_set<std::uintptr_t> results;
+	std::unordered_set<std::uintptr_t> results;
 	results.reserve(seeds.size());
 	for (const auto& seed : seeds) {
 		results.insert(REL::ID(seed).address());

--- a/RTTIDump/xmake.lua
+++ b/RTTIDump/xmake.lua
@@ -12,7 +12,7 @@ target("RTTIDump")
     add_deps("CommonLibF4")
 
     -- add packages
-    add_packages("robin-hood-hashing", "rsm-binary-io", "spdlog", "srell")
+    add_packages("spdlog", "srell")
 
     -- add source files
     add_files("src/**.cpp")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -18,7 +18,6 @@
     "frozen",
     "nowide",
     "rapidcsv",
-    "robin-hood-hashing",
     "rsm-binary-io",
     "rsm-mmio",
     "spdlog",

--- a/xmake.lua
+++ b/xmake.lua
@@ -11,7 +11,7 @@ set_warnings("allextra", "error")
 add_rules("mode.debug", "mode.release")
 
 -- require packages
-add_requires("boost", "catch2", "fmt", "rapidcsv", "robin-hood-hashing", "rsm-binary-io", "rsm-mmio", "srell", "xbyak")
+add_requires("boost", "catch2", "fmt", "rapidcsv", "rsm-binary-io", "rsm-mmio", "srell", "xbyak")
 add_requires("spdlog", { configs = { header_only = false, fmt_external = true } })
 
 -- include subprojects


### PR DESCRIPTION
`robin-hood-hashing` isn't necessary where it is used here as the performance is practically indistinguishable compared to the standard types when used with a relatively low number of values. `RTTIDump` in particular was only a ~4-10 millisecond difference not accounting for variance between runs. `AddressLibGen` may have a larger delta, but given the data set I believe it accepts, it is not large enough to warrant using `robin-hood-hashing` for.