### PR TITLE
refactor: various additions and changes

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -148,28 +148,28 @@
       "name": "runtimes-vr",
       "hidden": true,
       "cacheVariables": {
-        "ENABLE_FALLOUT_F4": "OFF"
+        "FALLOUT_SUPPORT_F4": "OFF"
       }
     },
     {
       "name": "runtimes-flat",
       "hidden": true,
       "cacheVariables": {
-        "ENABLE_FALLOUT_VR": "OFF"
+        "FALLOUT_SUPPORT_VR": "OFF"
       }
     },
     {
-      "name": "runtimes-se",
+      "name": "runtimes-f4",
       "hidden": true,
       "cacheVariables": {
-        "ENABLE_FALLOUT_VR": "OFF"
+        "FALLOUT_SUPPORT_VR": "OFF"
       }
     },
     {
       "name": "runtimes-current",
       "hidden": true,
       "cacheVariables": {
-        "ENABLE_FALLOUT_F4": "OFF"
+        "FALLOUT_SUPPORT_F4": "OFF"
       }
     },
     {
@@ -236,7 +236,7 @@
       "name": "build-debug-msvc-vcpkg-f4",
       "inherits": [
         "build-debug-msvc-vcpkg-all",
-        "runtimes-se"
+        "runtimes-f4"
       ],
       "binaryDir": "${sourceDir}/build/debug-msvc-vcpkg-f4"
     },
@@ -244,7 +244,7 @@
       "name": "build-debug-clang-cl-vcpkg-f4",
       "inherits": [
         "build-debug-clang-cl-vcpkg-all",
-        "runtimes-se"
+        "runtimes-f4"
       ],
       "binaryDir": "${sourceDir}/build/debug-clang-cl-vcpkg-f4"
     },
@@ -328,7 +328,7 @@
       "name": "build-release-msvc-vcpkg-f4",
       "inherits": [
         "build-release-msvc-vcpkg-all",
-        "runtimes-se"
+        "runtimes-f4"
       ],
       "binaryDir": "${sourceDir}/build/release-msvc-vcpkg-f4"
     },
@@ -336,7 +336,7 @@
       "name": "build-release-clang-cl-vcpkg-f4",
       "inherits": [
         "build-release-clang-cl-vcpkg-all",
-        "runtimes-se"
+        "runtimes-f4"
       ],
       "binaryDir": "${sourceDir}/build/release-clang-cl-vcpkg-f4"
     },
@@ -420,7 +420,7 @@
       "name": "build-debug-msvc-conan-f4",
       "inherits": [
         "build-debug-msvc-conan-all",
-        "runtimes-se"
+        "runtimes-f4"
       ],
       "binaryDir": "${sourceDir}/build/debug-msvc-conan-f4"
     },
@@ -428,7 +428,7 @@
       "name": "build-debug-clang-cl-conan-f4",
       "inherits": [
         "build-debug-clang-cl-conan-all",
-        "runtimes-se"
+        "runtimes-f4"
       ],
       "binaryDir": "${sourceDir}/build/debug-clang-cl-conan-f4"
     },
@@ -512,7 +512,7 @@
       "name": "build-release-msvc-conan-f4",
       "inherits": [
         "build-release-msvc-conan-all",
-        "runtimes-se"
+        "runtimes-f4"
       ],
       "binaryDir": "${sourceDir}/build/release-msvc-conan-f4"
     },
@@ -520,7 +520,7 @@
       "name": "build-release-clang-cl-conan-f4",
       "inherits": [
         "build-release-clang-cl-conan-all",
-        "runtimes-se"
+        "runtimes-f4"
       ],
       "binaryDir": "${sourceDir}/build/release-clang-cl-conan-f4"
     },

--- a/CommonLibF4/CMakeLists.txt
+++ b/CommonLibF4/CMakeLists.txt
@@ -1,16 +1,16 @@
 cmake_minimum_required(VERSION 3.21)
 
 option(F4SE_SUPPORT_XBYAK "Enables trampoline support for Xbyak." OFF)
-option(ENABLE_FALLOUT_F4 "Enable support for Fallout 4 in the dynamic runtime feature." ON)
-option(ENABLE_FALLOUT_VR "Enable support for Fallout 4 VR in the dynamic runtime feature." ON)
+option(FALLOUT_SUPPORT_F4 "Enable support for Fallout 4 in the dynamic runtime feature." ON)
+option(FALLOUT_SUPPORT_VR "Enable support for Fallout 4 VR in the dynamic runtime feature." ON)
 option(BUILD_TESTS "Enable building of the unit tests." OFF)
 message("Options:")
 message("\tEnable Xbyak: ${F4SE_SUPPORT_XBYAK}")
-message("\tEnable Fallout 4: ${ENABLE_FALLOUT_F4}")
-message("\tEnable Fallout 4 VR: ${ENABLE_FALLOUT_VR}")
+message("\tEnable Fallout 4: ${FALLOUT_SUPPORT_F4}")
+message("\tEnable Fallout 4 VR: ${FALLOUT_SUPPORT_VR}")
 message("\tBuild Tests: ${BUILD_TESTS}")
 
-if(NOT ENABLE_FALLOUT_F4 AND NOT ENABLE_FALLOUT_VR)
+if(NOT FALLOUT_SUPPORT_F4 AND NOT FALLOUT_SUPPORT_VR)
 	message(FATAL_ERROR "At least one Fallout runtime must be supported by the COMMONLIBF4 build.")
 endif()
 
@@ -60,9 +60,8 @@ target_compile_definitions(
 		WINVER=0x0601	# windows 7, minimum supported version by Fallout
 		_WIN32_WINNT=0x0601
 		"$<$<BOOL:${F4SE_SUPPORT_XBYAK}>:F4SE_SUPPORT_XBYAK=1>"
-		"$<$<BOOL:${ENABLE_FALLOUT_F4}>:ENABLE_FALLOUT_F4=1>"
-		"$<$<BOOL:${ENABLE_FALLOUT_VR}>:ENABLE_FALLOUT_VR=1>"
-		HAS_FALLOUT_MULTI_TARGETING=1
+		"$<$<BOOL:${FALLOUT_SUPPORT_F4}>:FALLOUT_SUPPORT_F4=1>"
+		"$<$<BOOL:${FALLOUT_SUPPORT_VR}>:FALLOUT_SUPPORT_VR=1>"
 )
 
 target_compile_features(
@@ -197,7 +196,7 @@ if(BUILD_TESTS)
 	target_compile_definitions(
 		"${PROJECT_NAME}Tests"
 		PUBLIC
-			ENABLE_COMMONLIBF4_TESTING=1
+			COMMONLIBF4_ENABLE_TESTING=1
 	)
 
 	target_link_libraries(

--- a/CommonLibF4/cmake/sourcelist.cmake
+++ b/CommonLibF4/cmake/sourcelist.cmake
@@ -3,6 +3,7 @@ set(SOURCES
 	include/F4SE/F4SE.h
 	include/F4SE/Impl/PCH.h
 	include/F4SE/Impl/WinAPI.h
+	include/F4SE/Impl/WinSTL.h
 	include/F4SE/Interfaces.h
 	include/F4SE/Logger.h
 	include/F4SE/Trampoline.h

--- a/CommonLibF4/include/F4SE/Impl/PCH.h
+++ b/CommonLibF4/include/F4SE/Impl/PCH.h
@@ -788,7 +788,7 @@ namespace F4SE
 				a_msg);
 
 			if (a_fail) {
-#ifdef ENABLE_COMMONLIBF4_TESTING
+#ifdef COMMONLIBF4_ENABLE_TESTING
 				throw std::runtime_error(utf16_to_utf8(caption.empty() ? body.c_str() : caption.c_str())->c_str());
 #else
 				WinAPI::MessageBox(nullptr, body.c_str(), (caption.empty() ? nullptr : caption.c_str()), 0);

--- a/CommonLibF4/include/F4SE/Impl/PCH.h
+++ b/CommonLibF4/include/F4SE/Impl/PCH.h
@@ -67,6 +67,7 @@ static_assert(
 #pragma warning(pop)
 
 #include "F4SE/Impl/WinAPI.h"
+#include "F4SE/Impl/WinSTL.h"
 
 namespace F4SE
 {
@@ -861,6 +862,7 @@ namespace RE
 	using namespace std::literals;
 	namespace stl = F4SE::stl;
 	namespace WinAPI = F4SE::WinAPI;
+	namespace WinSTL = F4SE::WinSTL;
 }
 
 namespace REL
@@ -868,6 +870,7 @@ namespace REL
 	using namespace std::literals;
 	namespace stl = F4SE::stl;
 	namespace WinAPI = F4SE::WinAPI;
+	namespace WinSTL = F4SE::WinSTL;
 }
 
 #include "REL/Relocation.h"

--- a/CommonLibF4/include/F4SE/Impl/WinAPI.h
+++ b/CommonLibF4/include/F4SE/Impl/WinAPI.h
@@ -574,7 +574,17 @@ namespace F4SE::WinAPI
 		std::uint32_t a_flags,
 		std::uint32_t* a_threadId) noexcept;
 
-	[[nodiscard]] bool FindClose(
+	std::uint32_t ExpandEnvironmentStrings(
+		const char* a_src,
+		char* a_dest,
+		std::uint32_t a_size) noexcept;
+
+	std::uint32_t ExpandEnvironmentStrings(
+		const wchar_t* a_src,
+		wchar_t* a_dest,
+		std::uint32_t a_size) noexcept;
+
+	bool FindClose(
 		void* a_findFile) noexcept;
 
 	[[nodiscard]] void* FindFirstFile(

--- a/CommonLibF4/include/F4SE/Impl/WinSTL.h
+++ b/CommonLibF4/include/F4SE/Impl/WinSTL.h
@@ -1,0 +1,36 @@
+#pragma once
+
+namespace F4SE::WinSTL
+{
+	inline std::string GetEnvironmentVariable(
+		std::string_view a_name,
+		std::size_t a_maxSize = 1024u)
+	{
+		if (a_name.empty() || !a_maxSize)
+			return {};
+
+		std::string buffer(a_maxSize + 1, 0);
+		const auto result = WinAPI::GetEnvironmentVariable(
+			a_name.data(),
+			buffer.data(),
+			static_cast<std::uint32_t>(a_maxSize));
+
+		return { buffer.c_str() };
+	}
+
+	inline std::wstring GetEnvironmentVariable(
+		std::wstring_view a_name,
+		std::size_t a_maxSize = 1024u)
+	{
+		if (a_name.empty() || !a_maxSize)
+			return {};
+
+		std::wstring buffer(a_maxSize + 1, 0);
+		const auto result = WinAPI::GetEnvironmentVariable(
+			a_name.data(),
+			buffer.data(),
+			static_cast<std::uint32_t>(a_maxSize));
+
+		return { buffer.c_str() };
+	}
+}

--- a/CommonLibF4/include/REL/Relocation.h
+++ b/CommonLibF4/include/REL/Relocation.h
@@ -861,25 +861,10 @@ namespace REL
 
 		Module& operator=(Module&&) = delete;
 
-		static inline std::wstring safeGetEnvWstring(const std::wstring_view& envVar, std::size_t maxSize)
-		{
-			if (!maxSize) {
-				return std::wstring();
-			}
-			std::wstring _tempstr;
-			_tempstr.resize(maxSize + 1);
-			std::fill(_tempstr.begin(), _tempstr.end(), '\0');
-			const auto result = WinAPI::GetEnvironmentVariable(
-				envVar.data(),
-				_tempstr.data(),
-				static_cast<std::uint32_t>(maxSize));
-			return { _tempstr.c_str() };  // wstring_view(wchar_t*) constructor removes trailing '\0'
-		}
-
 		bool init()
 		{
 			auto sz = _filename.size();
-			_filename = safeGetEnvWstring(ENVIRONMENT, sz);
+			_filename = WinSTL::GetEnvironmentVariable(ENVIRONMENT, sz);
 			void* moduleHandle = nullptr;
 			if (_filename.empty() || _filename.size() != sz) {
 				for (auto runtime : RUNTIMES) {

--- a/CommonLibF4/include/REL/Relocation.h
+++ b/CommonLibF4/include/REL/Relocation.h
@@ -1491,6 +1491,8 @@ namespace REL
 #endif
 	};
 
+	using VariantOffset = Offset2; // deprecated
+
 	class ID
 	{
 	public:
@@ -1586,6 +1588,8 @@ namespace REL
 		std::uint64_t _vrID{ 0 };
 #endif
 	};
+
+	using RelocationID = ID2; // deprecated
 
 	template <class T>
 	class Relocation

--- a/CommonLibF4/include/REL/Relocation.h
+++ b/CommonLibF4/include/REL/Relocation.h
@@ -58,14 +58,14 @@
 	REL_MAKE_MEMBER_FUNCTION_NON_POD_TYPE_HELPER(&, ##__VA_ARGS__) \
 	REL_MAKE_MEMBER_FUNCTION_NON_POD_TYPE_HELPER(&&, ##__VA_ARGS__)
 
-#if defined(ENABLE_FALLOUT_VR) && (defined(ENABLE_FALLOUT_F4))
+#if defined(FALLOUT_SUPPORT_F4) && (FALLOUT_SUPPORT_VR)
 /**
  * Defined to indicate that this build supports both VR and non-VR runtimes.
  */
-#	define FALLOUT_CROSS_VR
+#	define FALLOUT_SUPPORT_CROSS 1
 #endif
 
-#if (!defined(ENABLE_FALLOUT_F4) && !defined(ENABLE_FALLOUT_VR))
+#if !defined(FALLOUT_SUPPORT_F4) && !defined(FALLOUT_SUPPORT_VR)
 /**
  * A macro which defines a modifier for expressions that vary by FALLOUT Address Library IDs.
  *
@@ -85,7 +85,7 @@
 #	define FALLOUT_ADDR inline
 #endif
 
-#if !defined(ENABLE_FALLOUT_VR) || (!defined(ENABLE_FALLOUT_F4) && !defined(ENABLE_FALLOUT_VR)) || (!defined(ENABLE_FALLOUT_F4))
+#if !defined(FALLOUT_SUPPORT_F4) || (!defined(FALLOUT_SUPPORT_F4) && !defined(FALLOUT_SUPPORT_VR)) || !defined(FALLOUT_SUPPORT_VR)
 /**
  * A macro which defines a modifier for expressions that vary by the specific FALLOUT runtime.
  *
@@ -123,9 +123,9 @@
 #	define FALLOUT_REL_CONSTEXPR
 #endif
 
-#ifndef FALLOUT_CROSS_VR
+#ifndef FALLOUT_SUPPORT_CROSS
 /**
- * A macro which defines a modifier for expressions that vary between FALLOUT SE/AE and FALLOUT VR.
+ * A macro which defines a modifier for expressions that vary between FALLOUT 4 and FALLOUT VR.
  *
  * <p>
  * Currently defined as <code>constexpr</code> since this build is only for VR or non-VR.
@@ -687,7 +687,7 @@ namespace REL
 			return _instance;
 		}
 
-#ifdef ENABLE_COMMONLIBF4_TESTING
+#ifdef COMMONLIBF4_ENABLE_TESTING
 		/**
          * Forcibly set the singleton <code>Module</code> instance to a specific executable file.
          *
@@ -736,7 +736,7 @@ namespace REL
 					LR"(SOFTWARE\Bethesda Softworks\Fallout 4)";
 			unsigned long length = bufferSize * sizeof(wchar_t);
 			std::uint8_t value[bufferSize];
-			if (WinAPI::RegGetValueW(WinAPI::HKEY_LOCAL_MACHINE, subKey, L"Installed Path", 0x20002, nullptr, value, &length) !=
+			if (WinAPI::RegGetValue(WinAPI::HKEY_LOCAL_MACHINE, subKey, L"Installed Path", 0x20002, nullptr, value, &length) !=
 				0) {
 				return false;
 			}
@@ -745,8 +745,11 @@ namespace REL
 			return inject(installPath.c_str());
 		}
 
-		static bool mock(REL::Version a_version, Runtime a_runtime = Runtime::Unknown,
-			std::wstring_view a_filename = L"Fallout4.exe"sv, std::uintptr_t a_base = 0,
+		static bool mock(
+			REL::Version a_version, 
+			Runtime a_runtime = Runtime::Unknown,
+			std::wstring_view a_filename = L"Fallout4.exe"sv, 
+			std::uintptr_t a_base = 0,
 			std::array<std::uintptr_t, Segment::total> a_segmentSizes = { 0x1603000, 0, 0x8ee000, 0x1887000, 0x15c000, 0x3000, 0x2000, 0x1000 })
 		{
 			_instance.clear();
@@ -760,11 +763,8 @@ namespace REL
 			_instance._version = a_version;
 			if (a_runtime == Runtime::Unknown) {
 				switch (a_version[1]) {
-				case 4:
+				case 2:
 					_instance._runtime = Runtime::VR;
-					break;
-				case 6:
-					_instance._runtime = Runtime::AE;
 					break;
 				default:
 					_instance._runtime = Runtime::F4;
@@ -817,9 +817,9 @@ namespace REL
          */
 		[[nodiscard]] static FALLOUT_REL Runtime GetRuntime() noexcept
 		{
-#if (!defined(ENABLE_FALLOUT_VR))
+#if !defined(FALLOUT_SUPPORT_VR)
 			return Runtime::F4;
-#elif (!defined(ENABLE_FALLOUT_F4))
+#elif !defined(FALLOUT_SUPPORT_F4)
 			return Runtime::VR;
 #else
 			return get()._runtime;
@@ -839,9 +839,9 @@ namespace REL
          */
 		[[nodiscard]] static FALLOUT_REL_VR bool IsVR() noexcept
 		{
-#ifndef ENABLE_FALLOUT_VR
+#if !defined(FALLOUT_SUPPORT_VR)
 			return false;
-#elif !defined(ENABLE_FALLOUT_F4)
+#elif !defined(FALLOUT_SUPPORT_F4)
 			return true;
 #else
 			return GetRuntime() == Runtime::VR;
@@ -850,15 +850,12 @@ namespace REL
 
 	private:
 		Module() = default;
-
 		Module(const Module&) = delete;
-
 		Module(Module&&) = delete;
 
 		~Module() noexcept = default;
 
 		Module& operator=(const Module&) = delete;
-
 		Module& operator=(Module&&) = delete;
 
 		bool init()
@@ -1059,7 +1056,7 @@ namespace REL
 			return _instance;
 		}
 
-#ifdef ENABLE_COMMONLIBF4_TESTING
+#ifdef COMMONLIBF4_ENABLE_TESTING
 		[[nodiscard]] static bool inject(std::wstring_view a_filePath, Format a_format)
 		{
 			return inject(a_filePath, a_format, Module::get().version());
@@ -1215,15 +1212,12 @@ namespace REL
 		};
 
 		IDDatabase() = default;
-
 		IDDatabase(const IDDatabase&) = delete;
-
 		IDDatabase(IDDatabase&&) = delete;
 
 		~IDDatabase() = default;
 
 		IDDatabase& operator=(const IDDatabase&) = delete;
-
 		IDDatabase& operator=(IDDatabase&&) = delete;
 
 		void load()
@@ -1446,36 +1440,36 @@ namespace REL
 		std::size_t _offset{ 0 };
 	};
 
-	class VariantOffset
+	class Offset2
 	{
 	public:
-		constexpr VariantOffset() noexcept = default;
+		constexpr Offset2() noexcept = default;
 
-		explicit constexpr VariantOffset([[maybe_unused]] std::size_t a_f4Offset,
+		explicit constexpr Offset2(
+			[[maybe_unused]] std::size_t a_f4Offset,
 			[[maybe_unused]] std::size_t a_vrOffset) noexcept
 		{
-#ifdef ENABLE_FALLOUT_F4
+#ifdef FALLOUT_SUPPORT_F4
 			_f4Offset = a_f4Offset;
 #endif
-#ifdef ENABLE_FALLOUT_VR
+#ifdef FALLOUT_SUPPORT_VR
 			_vrOffset = a_vrOffset;
 #endif
 		}
 
 		[[nodiscard]] std::uintptr_t address() const
 		{
-			auto thisOffset = offset();
-			return thisOffset ? base() + thisOffset : 0;
+			return offset() ? base() + offset() : 0;
 		}
 
 		[[nodiscard]] FALLOUT_REL std::size_t offset() const noexcept
 		{
 			switch (Module::GetRuntime()) {
-#ifdef ENABLE_FALLOUT_F4
+#ifdef FALLOUT_SUPPORT_F4
 			case Module::Runtime::F4:
 				return _f4Offset;
 #endif
-#ifdef ENABLE_FALLOUT_VR
+#ifdef FALLOUT_SUPPORT_VR
 			case Module::Runtime::VR:
 				return _vrOffset;
 #endif
@@ -1489,10 +1483,10 @@ namespace REL
 	private:
 		[[nodiscard]] static std::uintptr_t base() { return Module::get().base(); }
 
-#ifdef ENABLE_FALLOUT_F4
+#ifdef FALLOUT_SUPPORT_F4
 		std::size_t _f4Offset{ 0 };
 #endif
-#ifdef ENABLE_FALLOUT_VR
+#ifdef FALLOUT_SUPPORT_VR
 		std::size_t _vrOffset{ 0 };
 #endif
 	};
@@ -1523,52 +1517,52 @@ namespace REL
 		std::uint64_t _id{ 0 };
 	};
 
-	class RelocationID
+	class ID2
 	{
 	public:
-		constexpr RelocationID() noexcept = default;
+		constexpr ID2() noexcept = default;
 
-		explicit constexpr RelocationID([[maybe_unused]] std::uint64_t a_f4ID) noexcept
+		explicit constexpr ID2(
+			[[maybe_unused]] std::uint64_t a_f4ID) noexcept
 		{
-#ifdef ENABLE_FALLOUT_F4
+#ifdef FALLOUT_SUPPORT_F4
 			_f4ID = a_f4ID;
 #endif
-#ifdef ENABLE_FALLOUT_VR
+#ifdef FALLOUT_SUPPORT_VR
 			_vrID = a_f4ID;
 #endif
 		}
 
-		explicit constexpr RelocationID([[maybe_unused]] std::uint64_t a_f4ID,
+		explicit constexpr ID2(
+			[[maybe_unused]] std::uint64_t a_f4ID,
 			[[maybe_unused]] std::uint64_t a_vrID) noexcept
 		{
-#ifdef ENABLE_FALLOUT_F4
+#ifdef FALLOUT_SUPPORT_F4
 			_f4ID = a_f4ID;
 #endif
-#ifdef ENABLE_FALLOUT_VR
+#ifdef FALLOUT_SUPPORT_VR
 			_vrID = a_vrID;
 #endif
 		}
 
 		[[nodiscard]] std::uintptr_t address() const
 		{
-			auto thisOffset = offset();
-			return thisOffset ? base() + offset() : 0;
+			return offset() ? base() + offset() : 0;
 		}
 
 		[[nodiscard]] std::size_t offset() const
 		{
-			auto thisID = id();
-			return thisID ? IDDatabase::get().id2offset(thisID) : 0;
+			return id() ? IDDatabase::get().id2offset(id()) : 0;
 		}
 
 		[[nodiscard]] FALLOUT_REL std::uint64_t id() const noexcept
 		{
 			switch (Module::GetRuntime()) {
-#ifdef ENABLE_FALLOUT_F4
+#ifdef FALLOUT_SUPPORT_F4
 			case Module::Runtime::F4:
 				return _f4ID;
 #endif
-#ifdef ENABLE_FALLOUT_VR
+#ifdef FALLOUT_SUPPORT_VR
 			case Module::Runtime::VR:
 				return _vrID;
 #endif
@@ -1585,60 +1579,11 @@ namespace REL
 	private:
 		[[nodiscard]] static std::uintptr_t base() { return Module::get().base(); }
 
-#ifdef ENABLE_FALLOUT_F4
+#ifdef FALLOUT_SUPPORT_F4
 		std::uint64_t _f4ID{ 0 };
 #endif
-#ifdef ENABLE_FALLOUT_VR
+#ifdef FALLOUT_SUPPORT_VR
 		std::uint64_t _vrID{ 0 };
-#endif
-	};
-
-	class VariantID
-	{
-	public:
-		constexpr VariantID() noexcept = default;
-
-		explicit constexpr VariantID([[maybe_unused]] std::uint64_t a_f4ID,
-			[[maybe_unused]] std::uint64_t a_vrOffset) noexcept
-		{
-#ifdef ENABLE_FALLOUT_F4
-			_f4ID = a_f4ID;
-#endif
-#ifdef ENABLE_FALLOUT_VR
-			_vrOffset = a_vrOffset;
-#endif
-		}
-
-		[[nodiscard]] std::uintptr_t address() const
-		{
-			auto thisOffset = offset();
-			return thisOffset ? base() + offset() : 0;
-		}
-
-		[[nodiscard]] std::size_t offset() const
-		{
-			switch (Module::GetRuntime()) {
-#ifdef ENABLE_FALLOUT_F4
-			case Module::Runtime::F4:
-				return _f4ID ? IDDatabase::get().id2offset(_f4ID) : 0;
-#endif
-#ifdef ENABLE_FALLOUT_VR
-			case Module::Runtime::VR:
-				return _vrOffset;
-#endif
-			default:
-				return 0;
-			}
-		}
-
-	private:
-		[[nodiscard]] static std::uintptr_t base() { return Module::get().base(); }
-
-#ifdef ENABLE_FALLOUT_F4
-		std::uint64_t _f4ID{ 0 };
-#endif
-#ifdef ENABLE_FALLOUT_VR
-		std::uint64_t _vrOffset{ 0 };
 #endif
 	};
 
@@ -1660,7 +1605,7 @@ namespace REL
 		explicit Relocation(Offset a_offset) :
 			_impl{ a_offset.address() } {}
 
-		explicit Relocation(VariantOffset a_offset) :
+		explicit Relocation(Offset2 a_offset) :
 			_impl{ a_offset.address() } {}
 
 		explicit Relocation(ID a_id) :
@@ -1672,31 +1617,19 @@ namespace REL
 		explicit Relocation(ID a_id, Offset a_offset) :
 			_impl{ a_id.address() + a_offset.offset() } {}
 
-		explicit Relocation(ID a_id, VariantOffset a_offset) :
+		explicit Relocation(ID a_id, Offset2 a_offset) :
 			_impl{ a_id.address() + a_offset.offset() } {}
 
-		explicit Relocation(RelocationID a_id) :
+		explicit Relocation(ID2 a_id) :
 			_impl{ a_id.address() } {}
 
-		explicit Relocation(RelocationID a_id, std::ptrdiff_t a_offset) :
+		explicit Relocation(ID2 a_id, std::ptrdiff_t a_offset) :
 			_impl{ a_id.address() + a_offset } {}
 
-		explicit Relocation(RelocationID a_id, Offset a_offset) :
+		explicit Relocation(ID2 a_id, Offset a_offset) :
 			_impl{ a_id.address() + a_offset.offset() } {}
 
-		explicit Relocation(RelocationID a_id, VariantOffset a_offset) :
-			_impl{ a_id.address() + a_offset.offset() } {}
-
-		explicit Relocation(VariantID a_id) :
-			_impl{ a_id.address() } {}
-
-		explicit Relocation(VariantID a_id, std::ptrdiff_t a_offset) :
-			_impl{ a_id.address() + a_offset } {}
-
-		explicit Relocation(VariantID a_id, Offset a_offset) :
-			_impl{ a_id.address() + a_offset.offset() } {}
-
-		explicit Relocation(VariantID a_id, VariantOffset a_offset) :
+		explicit Relocation(ID2 a_id, Offset2 a_offset) :
 			_impl{ a_id.address() + a_offset.offset() } {}
 
 		constexpr Relocation& operator=(std::uintptr_t a_address) noexcept
@@ -1711,7 +1644,7 @@ namespace REL
 			return *this;
 		}
 
-		Relocation& operator=(VariantOffset a_offset)
+		Relocation& operator=(Offset2 a_offset)
 		{
 			_impl = a_offset.address();
 			return *this;
@@ -1723,13 +1656,7 @@ namespace REL
 			return *this;
 		}
 
-		Relocation& operator=(RelocationID a_id)
-		{
-			_impl = a_id.address();
-			return *this;
-		}
-
-		Relocation& operator=(VariantID a_id)
+		Relocation& operator=(ID2 a_id)
 		{
 			_impl = a_id.address();
 			return *this;
@@ -2017,18 +1944,16 @@ namespace REL
      * </p>
      *
      * @tparam T the type of value to return.
-     * @param a_f4 the value to use for SE.
-     * @param a_ae the value to use for AE.
+     * @param a_f4 the value to use for F4.
      * @param a_vr the value to use for VR.
-     * @return Either <code>a_f4</code> if the current runtime is FALLOUT SE, or <code>a_ae</code> if the runtime is AE, or
-     * <code>a_vr</code> if running FALLOUT VR.
+     * @return Either <code>a_f4</code> if the current runtime is F4, or <code>a_vr</code> if the runtime is VR
      */
 	template <class T>
 	[[nodiscard]] FALLOUT_REL T Relocate([[maybe_unused]] T a_f4, [[maybe_unused]] T a_vr) noexcept
 	{
-#if !defined(ENABLE_FALLOUT_VR)
+#if !defined(FALLOUT_SUPPORT_VR)
 		return a_f4;
-#elif !defined(ENABLE_FALLOUT_F4)
+#elif !defined(FALLOUT_SUPPORT_F4)
 		return a_vr;
 #else
 		switch (Module::get().GetRuntime()) {
@@ -2100,7 +2025,7 @@ namespace REL
      * Invokes a virtual function in a cross-platform way where the vtable structure is variant across AE/SE and VR runtimes.
      *
      * <p>
-     * Some classes in FALLOUT VR add new virtual functions in the middle of the vtable structure, which makes it ABI-incompatible with AE/SE.
+     * Some classes in FALLOUT VR add new virtual functions in the middle of the vtable structure, which makes it ABI-incompatible with F4.
      * A naive virtual function call, therefore, cannot work across all runtimes without the plugin being recompiled specifically for VR.
      * This call works with types which have variant vtables to allow a non-virtual function definition to be created in the virtual function's
      * place, and to have that call dynamically lookup the correct function based on the vtable structure expected in the current runtime.
@@ -2108,7 +2033,7 @@ namespace REL
      *
      * @tparam Fn the type of the function being called.
      * @tparam Args the types of the arguments being passed.
-     * @param a_f4tableOffset the offset from the <code>this</code> pointer to the vtable with the virtual function in SE/AE.
+     * @param a_f4tableOffset the offset from the <code>this</code> pointer to the vtable with the virtual function in F4.
      * @param a_vrVtableIndex the offset from the <code>this</code> pointer to the vtable with the virtual function in VR.
      * @param a_f4tableIndex the index of the function in the class' vtable in F4.
      * @param a_vrVtableIndex the index of the function in the class' vtable in VR.
@@ -2124,10 +2049,10 @@ namespace REL
 	{
 		return (*reinterpret_cast<typename detail::RelocateVirtualHelper<Fn>::function_type**>(
 			*reinterpret_cast<const uintptr_t*>(reinterpret_cast<uintptr_t>(a_f4lf) +
-#ifndef ENABLE_FALLOUT_VR
+#if !defined(FALLOUT_SUPPORT_VR)
 												a_f4tableOffset) +
 			a_f4tableIndex
-#elif !defined(ENABLE_FALLOUT_F4)
+#elif !defined(FALLOUT_SUPPORT_F4)
 												a_vrVtableOffset) +
 			a_vrVtableIndex
 #else
@@ -2141,7 +2066,7 @@ namespace REL
      * Invokes a virtual function in a cross-platform way where the vtable structure is variant across AE/SE and VR runtimes.
      *
      * <p>
-     * Some classes in FALLOUT VR add new virtual functions in the middle of the vtable structure, which makes it ABI-incompatible with AE/SE.
+     * Some classes in FALLOUT VR add new virtual functions in the middle of the vtable structure, which makes it ABI-incompatible with F4.
      * A naive virtual function call, therefore, cannot work across all runtimes without the plugin being recompiled specifically for VR.
      * This call works with types which have variant vtables to allow a non-virtual function definition to be created in the virtual function's
      * place, and to have that call dynamically lookup the correct function based on the vtable structure expected in the current runtime.
@@ -2234,6 +2159,7 @@ namespace std
 #endif
 }
 
+#ifdef FMT_VERSION
 namespace fmt
 {
 	template <class CharT>
@@ -2246,6 +2172,7 @@ namespace fmt
 		}
 	};
 }
+#endif
 
 #undef REL_MAKE_MEMBER_FUNCTION_NON_POD_TYPE
 #undef REL_MAKE_MEMBER_FUNCTION_NON_POD_TYPE_HELPER

--- a/CommonLibF4/include/REL/Relocation.h
+++ b/CommonLibF4/include/REL/Relocation.h
@@ -1491,7 +1491,7 @@ namespace REL
 #endif
 	};
 
-	using VariantOffset = Offset2; // deprecated
+	using VariantOffset = Offset2;  // deprecated
 
 	class ID
 	{
@@ -1589,7 +1589,7 @@ namespace REL
 #endif
 	};
 
-	using RelocationID = ID2; // deprecated
+	using RelocationID = ID2;  // deprecated
 
 	template <class T>
 	class Relocation

--- a/CommonLibF4/src/F4SE/Impl/WinAPI.cpp
+++ b/CommonLibF4/src/F4SE/Impl/WinAPI.cpp
@@ -11,6 +11,7 @@
 
 #undef CreateFileMapping
 #undef CreateProcess
+#undef ExpandEnvironmentStrings
 #undef FindFirstFile
 #undef FindNextFile
 #undef GetEnvironmentVariable
@@ -155,6 +156,30 @@ namespace F4SE::WinAPI
 				static_cast<::LPVOID>(a_param),
 				static_cast<::DWORD>(a_flags),
 				reinterpret_cast<::LPDWORD>(a_threadId)));
+	}
+
+	std::uint32_t ExpandEnvironmentStrings(
+		const char* a_src,
+		char* a_dest,
+		std::uint32_t a_size) noexcept
+	{
+		return static_cast<std::uint32_t>(
+			::ExpandEnvironmentStringsA(
+				static_cast<::LPCSTR>(a_src),
+				static_cast<::LPSTR>(a_dest),
+				static_cast<::DWORD>(a_size)));
+	}
+
+	std::uint32_t ExpandEnvironmentStrings(
+		const wchar_t* a_src,
+		wchar_t* a_dest,
+		std::uint32_t a_size) noexcept
+	{
+		return static_cast<std::uint32_t>(
+			::ExpandEnvironmentStringsW(
+				static_cast<::LPCWSTR>(a_src),
+				static_cast<::LPWSTR>(a_dest),
+				static_cast<::DWORD>(a_size)));
 	}
 
 	bool FindClose(

--- a/CommonLibF4/xmake.lua
+++ b/CommonLibF4/xmake.lua
@@ -1,13 +1,13 @@
 option("fallout_f4", function()
     set_default(true)
     set_description("Enable runtime support for Fallout 4")
-    add_defines("ENABLE_FALLOUT_F4=1")
+    add_defines("FALLOUT_SUPPORT_F4=1")
 end)
 
 option("fallout_vr", function()
     set_default(true)
     set_description("Enable runtime support for Fallout 4 VR")
-    add_defines("ENABLE_FALLOUT_VR=1")
+    add_defines("FALLOUT_SUPPORT_VR=1")
 end)
 
 option("f4se_xbyak", function()

--- a/CommonLibF4/xmake.lua
+++ b/CommonLibF4/xmake.lua
@@ -56,34 +56,36 @@ target("CommonLibF4")
     add_cxxflags("cl::/we4715") -- `function` : not all control paths return a value
 
     -- add flags(disable warnings)
-    add_cxxflags("cl::/wd4005") -- macro redefinition
-    add_cxxflags("cl::/wd4061") -- enumerator `identifier` in switch of enum `enumeration` is not explicitly handled by a case label
-    add_cxxflags("cl::/wd4068") -- unknown pragma 'clang'
-    add_cxxflags("cl::/wd4200") -- nonstandard extension used : zero-sized array in struct/union
-    add_cxxflags("cl::/wd4201") -- nonstandard extension used : nameless struct/union
-    add_cxxflags("cl::/wd4264") -- 'virtual_function' : no override available for virtual member function from base 'class'; function is hidden
-    add_cxxflags("cl::/wd4265") -- 'type': class has virtual functions, but its non-trivial destructor is not virtual; instances of this class may not be destructed correctly
-    add_cxxflags("cl::/wd4266") -- 'function' : no override available for virtual member function from base 'type'; function is hidden
-    add_cxxflags("cl::/wd4324") -- 'struct_name' : structure was padded due to __declspec(align())
-    add_cxxflags("cl::/wd4371") -- 'classname': layout of class may have changed from a previous version of the compiler due to better packing of member 'member'
-    add_cxxflags("cl::/wd4514") -- 'function' : unreferenced inline function has been removed
-    add_cxxflags("cl::/wd4582") -- 'type': constructor is not implicitly called
-    add_cxxflags("cl::/wd4583") -- 'type': destructor is not implicitly called
-    add_cxxflags("cl::/wd4623") -- 'derived class' : default constructor was implicitly defined as deleted because a base class default constructor is inaccessible or deleted
-    add_cxxflags("cl::/wd4625") -- 'derived class' : copy constructor was implicitly defined as deleted because a base class copy constructor is inaccessible or deleted
-    add_cxxflags("cl::/wd4626") -- 'derived class' : assignment operator was implicitly defined as deleted because a base class assignment operator is inaccessible or deleted
-    add_cxxflags("cl::/wd4686") -- 'user-defined type' : possible change in behavior, change in UDT return calling convention
-    add_cxxflags("cl::/wd4710") -- 'function' : function not inlined
-    add_cxxflags("cl::/wd4711") -- function 'function' selected for inline expansion
-    add_cxxflags("cl::/wd4820") -- 'bytes' bytes padding added after construct 'member_name'
-    add_cxxflags("cl::/wd5082") -- second argument to 'va_start' is not the last named parameter
-    add_cxxflags("cl::/wd5026") -- 'type': move constructor was implicitly defined as deleted
-    add_cxxflags("cl::/wd5027") -- 'type': move assignment operator was implicitly defined as deleted
-    add_cxxflags("cl::/wd5045") -- compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
-    add_cxxflags("cl::/wd5053") -- support for 'explicit(<expr>)' in C++17 and earlier is a vendor extension
-    add_cxxflags("cl::/wd5105") -- macro expansion producing 'defined' has undefined behavior (workaround for older msvc bug)
-    add_cxxflags("cl::/wd5204") -- 'type-name': class has virtual functions, but its trivial destructor is not virtual; instances of objects derived from this class may not be destructed correctly
-    add_cxxflags("cl::/wd5220") -- 'member': a non-static data member with a volatile qualified type no longer implies that compiler generated copy / move constructors and copy / move assignment operators are not trivial
+    add_cxxflags(
+        "cl::/wd4005", -- macro redefinition
+        "cl::/wd4061", -- enumerator `identifier` in switch of enum `enumeration` is not explicitly handled by a case label
+        "cl::/wd4068", -- unknown pragma 'clang'
+        "cl::/wd4200", -- nonstandard extension used : zero-sized array in struct/union
+        "cl::/wd4201", -- nonstandard extension used : nameless struct/union
+        "cl::/wd4264", -- 'virtual_function' : no override available for virtual member function from base 'class'; function is hidden
+        "cl::/wd4265", -- 'type': class has virtual functions, but its non-trivial destructor is not virtual; instances of this class may not be destructed correctly
+        "cl::/wd4266", -- 'function' : no override available for virtual member function from base 'type'; function is hidden
+        "cl::/wd4324", -- 'struct_name' : structure was padded due to __declspec(align())
+        "cl::/wd4371", -- 'classname': layout of class may have changed from a previous version of the compiler due to better packing of member 'member'
+        "cl::/wd4514", -- 'function' : unreferenced inline function has been removed
+        "cl::/wd4582", -- 'type': constructor is not implicitly called
+        "cl::/wd4583", -- 'type': destructor is not implicitly called
+        "cl::/wd4623", -- 'derived class' : default constructor was implicitly defined as deleted because a base class default constructor is inaccessible or deleted
+        "cl::/wd4625", -- 'derived class' : copy constructor was implicitly defined as deleted because a base class copy constructor is inaccessible or deleted
+        "cl::/wd4626", -- 'derived class' : assignment operator was implicitly defined as deleted because a base class assignment operator is inaccessible or deleted
+        "cl::/wd4686", -- 'user-defined type' : possible change in behavior, change in UDT return calling convention
+        "cl::/wd4710", -- 'function' : function not inlined
+        "cl::/wd4711", -- function 'function' selected for inline expansion
+        "cl::/wd4820", -- 'bytes' bytes padding added after construct 'member_name'
+        "cl::/wd5082", -- second argument to 'va_start' is not the last named parameter
+        "cl::/wd5026", -- 'type': move constructor was implicitly defined as deleted
+        "cl::/wd5027", -- 'type': move assignment operator was implicitly defined as deleted
+        "cl::/wd5045", -- compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
+        "cl::/wd5053", -- support for 'explicit(<expr>)' in C++17 and earlier is a vendor extension
+        "cl::/wd5105", -- macro expansion producing 'defined' has undefined behavior (workaround for older msvc bug)
+        "cl::/wd5204", -- 'type-name': class has virtual functions, but its trivial destructor is not virtual; instances of objects derived from this class may not be destructed correctly
+        "cl::/wd5220"  -- 'member': a non-static data member with a volatile qualified type no longer implies that compiler generated copy / move constructors and copy / move assignment operators are not trivial
+    )
 
     -- add flags (clang)
     add_cxxflags("clang::-Wno-overloaded-virtual")


### PR DESCRIPTION
As the dynamic runtime stuff isn't being used yet I've taken the opportunity to change some class names to be shorter, as well as making the feature macros be the same. There is also a new header called `WinSTL` which is a sort of standard library for c++ to WinAPI helper utilities.

Opinionated changes:
`RelocationID` -> `ID2`
`VariantOffset` -> `Offset2`
`VariantID` -> gone for now, will likely come back in another form at a later date.