### PR TITLE
fix: windows 7 doesn't support `UnmapViewOfFileEx`

### DIFF
--- a/CommonLibF4/CMakeLists.txt
+++ b/CommonLibF4/CMakeLists.txt
@@ -57,8 +57,6 @@ add_library("${PROJECT_NAME}::${PROJECT_NAME}" ALIAS "${PROJECT_NAME}")
 target_compile_definitions(
 	"${PROJECT_NAME}"
 	PUBLIC
-		WINVER=0x0601	# windows 7, minimum supported version by Fallout
-		_WIN32_WINNT=0x0601
 		"$<$<BOOL:${F4SE_SUPPORT_XBYAK}>:F4SE_SUPPORT_XBYAK=1>"
 		"$<$<BOOL:${ENABLE_FALLOUT_F4}>:ENABLE_FALLOUT_F4=1>"
 		"$<$<BOOL:${ENABLE_FALLOUT_VR}>:ENABLE_FALLOUT_VR=1>"

--- a/CommonLibF4/include/F4SE/Impl/WinAPI.h
+++ b/CommonLibF4/include/F4SE/Impl/WinAPI.h
@@ -820,10 +820,6 @@ namespace F4SE::WinAPI
 	bool UnmapViewOfFile(
 		const void* a_baseAddress) noexcept;
 
-	bool UnmapViewOfFileEx(
-		void* a_baseAddress,
-		std::uint32_t a_flags) noexcept;
-
 	bool VerQueryValue(
 		const void* a_block,
 		const char* a_subBlock,

--- a/CommonLibF4/src/F4SE/Impl/WinAPI.cpp
+++ b/CommonLibF4/src/F4SE/Impl/WinAPI.cpp
@@ -2,6 +2,10 @@
 
 #define WIN32_LEAN_AND_MEAN
 
+// windows 7 is the minimum supported version by fallout
+#define WINVER 0x0601
+#define _WIN32_WINNT 0x0601
+
 // clang-format off
 #include <Windows.h>
 #include <DbgHelp.h>
@@ -720,14 +724,6 @@ namespace F4SE::WinAPI
 				static_cast<::LPVOID>(a_tlsValue)));
 	}
 
-	bool UnmapViewOfFile(
-		const void* a_baseAddress) noexcept
-	{
-		return static_cast<bool>(
-			::UnmapViewOfFile(
-				static_cast<::LPCVOID>(a_baseAddress)));
-	}
-
 	std::uint32_t UnDecorateSymbolName(
 		const char* a_name,
 		char* a_outputString,
@@ -756,14 +752,12 @@ namespace F4SE::WinAPI
 				static_cast<::DWORD>(a_flags)));
 	}
 
-	bool UnmapViewOfFileEx(
-		void* a_baseAddress,
-		std::uint32_t a_flags) noexcept
+	bool UnmapViewOfFile(
+		const void* a_baseAddress) noexcept
 	{
 		return static_cast<bool>(
-			::UnmapViewOfFileEx(
-				static_cast<::PVOID>(a_baseAddress),
-				static_cast<::ULONG>(a_flags)));
+			::UnmapViewOfFile(
+				static_cast<::LPCVOID>(a_baseAddress)));
 	}
 
 	bool VerQueryValue(


### PR DESCRIPTION
This function was introduced in Windows 8, but the library should try to stay compatible with what the game supports.