### PR TITLE
fix: missing F4SE header subdirectory in cmake install command

### DIFF
--- a/CommonLibF4/CMakeLists.txt
+++ b/CommonLibF4/CMakeLists.txt
@@ -175,6 +175,7 @@ install(
 
 install(
 	DIRECTORY
+ 	"include/F4SE"
 	"include/RE"
 	"include/REL"
 	"include/REX"


### PR DESCRIPTION
I believe this line was lost during a merge. Vcpkg ports don't play nice since files are manually copied over with CMake's install command rather than using add_subdirectory().

[CommonLibF4](https://github.com/Ryan-rsm-McKenzie/CommonLibF4/blob/master/CommonLibF4/CMakeLists.txt#L135) and [CommonLibSSE-NG](https://github.com/CharmedBaryon/CommonLibSSE-NG/blob/main/CMakeLists.txt#L176) for reference.