### PR TITLE
feat: update NiNode to support VR

### DIFF
--- a/CommonLibF4/include/RE/Bethesda/BSFadeNode.h
+++ b/CommonLibF4/include/RE/Bethesda/BSFadeNode.h
@@ -58,12 +58,12 @@ namespace RE
 		};
 		static_assert(sizeof(RUNTIME_DATA) == 0x80);
 
-		[[nodiscard]] inline RUNTIME_DATA& GetRuntimeData() noexcept
+		[[nodiscard]] inline RUNTIME_DATA& GetFadeNodeRuntimeData() noexcept
 		{
 			return REL::RelocateMember<RUNTIME_DATA>(this, 0x140, 0x180);
 		}
 
-		[[nodiscard]] inline const RUNTIME_DATA GetRuntimeData() const noexcept
+		[[nodiscard]] inline const RUNTIME_DATA& GetFadeNodeRuntimeData() const noexcept
 		{
 			return REL::RelocateMember<RUNTIME_DATA>(this, 0x140, 0x180);
 		}

--- a/CommonLibF4/include/RE/NetImmerse/NiNode.h
+++ b/CommonLibF4/include/RE/NetImmerse/NiNode.h
@@ -56,7 +56,7 @@ namespace RE
 			return REL::RelocateMember<RUNTIME_DATA>(this, 0x120, 0x160);
 		}
 
-		[[nodiscard]] inline const RUNTIME_DATA GetRuntimeData() const noexcept
+		[[nodiscard]] inline const RUNTIME_DATA& GetRuntimeData() const noexcept
 		{
 			return REL::RelocateMember<RUNTIME_DATA>(this, 0x120, 0x160);
 		}


### PR DESCRIPTION
- there are 64 bytes of something before the children collection that needs to be padded only in VR
- Used [Multiple Runtime Targeting](https://github.com/CharmedBaryon/CommonLibSSE-NG/wiki/Runtime-Targeting) to allows direct access to fields if either VR on non-VR exclusive
- Added `GetRuntimeData()` to handle targeting both VR and non-VR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal organization of certain classes by grouping related runtime data into nested structures, with accessor methods for cleaner access.
  * Adjusted memory layouts and size checks to better support different platforms or versions.

No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->