### PR TITLE
chore: fix "all" preset build after PR #27

### DIFF
--- a/CommonLibF4/include/RE/NetImmerse/NiNode.h
+++ b/CommonLibF4/include/RE/NetImmerse/NiNode.h
@@ -20,12 +20,12 @@ namespace RE
 			NiNode(0)
 		{}
 
-		explicit NiNode(std::uint32_t a_numChildren) :
-			children(a_numChildren)
+		explicit NiNode(std::uint32_t a_numChildren)
 		{
 			stl::emplace_vtable(this);
+			GetRuntimeData().children = NiTObjectArray<NiPointer<NiAVObject>>(a_numChildren);
 			static REL::Relocation<std::uintptr_t> childrenVTable{ REL::ID(390064) };
-			reinterpret_cast<std::uintptr_t&>(children) = childrenVTable.address();
+			reinterpret_cast<std::uintptr_t&>(GetRuntimeData().children) = childrenVTable.address();
 		}
 
 		// add

--- a/CommonLibF4/src/RE/Bethesda/BSVisit.cpp
+++ b/CommonLibF4/src/RE/Bethesda/BSVisit.cpp
@@ -21,7 +21,7 @@ namespace RE
 			auto result = BSVisitControl::kContinue;
 			auto node = a_object->IsNode();
 			if (node) {
-				for (auto& child : node->children) {
+				for (auto& child : node->GetRuntimeData().children) {
 					result = TraverseScenegraphGeometries(child.get(), a_func);
 					if (result == BSVisitControl::kStop) {
 						break;
@@ -46,7 +46,7 @@ namespace RE
 			result = BSVisitControl::kContinue;
 			auto node = a_object->IsNode();
 			if (node) {
-				for (auto& child : node->children) {
+				for (auto& child : node->GetRuntimeData().children) {
 					result = TraverseScenegraphObjects(child.get(), a_func);
 					if (result == BSVisitControl::kStop) {
 						break;


### PR DESCRIPTION
- direct access to `children` collection is no longer available and replaced with `GetRuntimeData().children`

Test: successful build with:
- build/release-msvc-vcpkg-vr
- build/release-msvc-vcpkg-flat
- build/release-msvc-vcpkg-all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal handling of scenegraph node children to use a runtime data accessor, improving consistency in how child nodes are managed and accessed. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->