### PR TITLE
feat: support VR in Nodes objects virtual functions

### DIFF
--- a/CommonLibF4/include/RE/NetImmerse/NiAVObject.h
+++ b/CommonLibF4/include/RE/NetImmerse/NiAVObject.h
@@ -38,13 +38,42 @@ namespace RE
 		virtual void        UpdateDownwardPass(NiUpdateData& a_data, std::uint32_t a_flags);                                    // 30
 		virtual void        UpdateSelectedDownwardPass(NiUpdateData& a_data, std::uint32_t a_flags);                            // 31
 		virtual void        UpdateRigidDownwardPass(NiUpdateData& a_data, std::uint32_t a_flags);                               // 32
-		virtual void        UpdateWorldBound() { return; }                                                                      // 33
-		virtual void        UpdateWorldData(NiUpdateData* a_data);                                                              // 34
-		virtual void        UpdateTransformAndBounds(NiUpdateData& a_data);                                                     // 35
-		virtual void        UpdateTransforms(NiUpdateData& a_data) { UpdateWorldData(std::addressof(a_data)); }                 // 36
-		virtual void        PreAttachUpdate(NiNode* a_eventualParent, NiUpdateData& a_data);                                    // 37
-		virtual void        PostAttachUpdate();                                                                                 // 38
-		virtual void        OnVisible([[maybe_unused]] NiCullingProcess& a_culler) { return; }                                  // 39
+
+		void UpdateWorldBound()  // 33
+		{
+			if (REL::Module::IsVR)
+				REL::RelocateVirtual<decltype(&NiAVObject::UpdateWorldBound)>(0x33, 0x33, this);
+		}
+
+		void UpdateWorldData(NiUpdateData* a_data)  // 34
+		{
+			REL::RelocateVirtual<decltype(&NiAVObject::UpdateWorldData)>(0x34, 0x37, this, a_data);
+		}
+
+		void UpdateTransformAndBounds(NiUpdateData& a_data)  // 35
+		{
+			REL::RelocateVirtual<decltype(&NiAVObject::UpdateTransformAndBounds)>(0x35, 0x38, this, a_data);
+		}
+
+		void UpdateTransforms(NiUpdateData& a_data)  // 36
+		{
+			if (REL::Module::IsVR)
+				REL::RelocateVirtual<decltype(&NiAVObject::UpdateTransforms)>(0x36, 0x39, this, a_data);
+			else
+				UpdateWorldData(std::addressof(a_data));
+		}
+
+		void PreAttachUpdate(NiNode* a_eventualParent, NiUpdateData& a_data)  // 37
+		{
+			REL::RelocateVirtual<decltype(&NiAVObject::PreAttachUpdate)>(0x3, 0x0, this, a_eventualParent, a_data);
+		}
+
+		void PostAttachUpdate()  // 38
+		{
+			REL::RelocateVirtual<decltype(&NiAVObject::PostAttachUpdate)>(0x3, 0x0, this);
+		}
+
+		void OnVisible([[maybe_unused]] NiCullingProcess& a_culler) { return; }  // 39
 
 		F4_HEAP_REDEFINE_ALIGNED_NEW(NiAVObject);
 

--- a/CommonLibF4/include/RE/NetImmerse/NiCamera.h
+++ b/CommonLibF4/include/RE/NetImmerse/NiCamera.h
@@ -24,8 +24,6 @@ namespace RE
 		virtual bool          RegisterStreamables(NiStream& a_stream) override;     // 1D
 		virtual void          SaveBinary(NiStream& a_stream) override;              // 1E
 		virtual bool          IsEqual(NiObject* a_object) override;                 // 1F
-		virtual void          UpdateWorldBound() override;                          // 33
-		virtual void          UpdateWorldData(NiUpdateData* a_data) override;       // 34
 
 		// members
 		float         worldToCam[4][4];  // 120

--- a/CommonLibF4/include/RE/NetImmerse/NiNode.h
+++ b/CommonLibF4/include/RE/NetImmerse/NiNode.h
@@ -29,15 +29,56 @@ namespace RE
 		}
 
 		// add
-		virtual void AttachChild(NiAVObject* a_child, bool a_firstAvail);                                 // 3A
-		virtual void InsertChildAt(std::uint32_t a_idx, NiAVObject* a_child);                             // 3B
-		virtual void DetachChild(NiAVObject* a_child);                                                    // 3D
-		virtual void DetachChild(NiAVObject* a_child, NiPointer<NiAVObject>& a_avObject);                 // 3C
-		virtual void DetachChildAt(std::uint32_t a_idx);                                                  // 3F
-		virtual void DetachChildAt(std::uint32_t a_idx, NiPointer<NiAVObject>& a_avObject);               // 3E
-		virtual void SetAt(std::uint32_t a_idx, NiAVObject* a_child);                                     // 41
-		virtual void SetAt(std::uint32_t a_idx, NiAVObject* a_child, NiPointer<NiAVObject>& a_avObject);  // 40
-		virtual void UpdateUpwardPass(NiUpdateData& a_data);                                              // 42
+		void AttachChild(NiAVObject* a_child, bool a_firstAvail)  // 3A
+		{
+			REL::RelocateVirtual<decltype(&NiNode::AttachChild)>(0x3A, 0x3D, this, a_child, a_firstAvail);
+		}
+
+		void InsertChildAt(std::uint32_t a_idx, NiAVObject* a_child)  // 3B
+		{
+			REL::RelocateVirtual<decltype(&NiNode::InsertChildAt)>(0x3B, 0x3E, this, a_idx, a_child);
+		}
+
+		void DetachChild(NiAVObject* a_child)  // 3D
+		{
+			using DetachChild = void (NiNode::*)(NiAVObject*);
+			REL::RelocateVirtual<DetachChild>(0x3C, 0x40, this, a_child);
+		}
+
+		void DetachChild(NiAVObject* a_child, NiPointer<NiAVObject>& a_avObject)  // 3C
+		{
+			using DetachChild = void (NiNode::*)(NiAVObject*, NiPointer<NiAVObject>&);
+			REL::RelocateVirtual<DetachChild>(0x3D, 0x3F, this, a_child, a_avObject);
+		}
+
+		void DetachChildAt(std::uint32_t a_idx)  // 3F
+		{
+			using DetachChildAt = void (NiNode::*)(std::uint32_t);
+			REL::RelocateVirtual<DetachChildAt>(0x3E, 0x42, this, a_idx);
+		}
+
+		void DetachChildAt(std::uint32_t a_idx, NiPointer<NiAVObject>& a_avObject)  // 3E
+		{
+			using DetachChildAt = void (NiNode::*)(std::uint32_t, NiPointer<NiAVObject>&);
+			REL::RelocateVirtual<DetachChildAt>(0x3F, 0x41, this, a_idx, a_avObject);
+		}
+
+		void SetAt(std::uint32_t a_idx, NiAVObject* a_child)  // 41
+		{
+			using SetAt = void (NiNode::*)(std::uint32_t, NiAVObject*);
+			REL::RelocateVirtual<SetAt>(0x40, 0x44, this, a_idx, a_child);
+		}
+
+		void SetAt(std::uint32_t a_idx, NiAVObject* a_child, NiPointer<NiAVObject>& a_avObject)  // 40
+		{
+			using SetAt = void (NiNode::*)(std::uint32_t, NiAVObject*, NiPointer<NiAVObject>&);
+			REL::RelocateVirtual<SetAt>(0x41, 0x43, this, a_idx, a_child, a_avObject);
+		}
+
+		void UpdateUpwardPass(NiUpdateData& a_data)  // 42
+		{
+			REL::RelocateVirtual<decltype(&NiNode::UpdateUpwardPass)>(0x42, 0x45, this, a_data);
+		}
 
 		F4_HEAP_REDEFINE_ALIGNED_NEW(NiNode);
 


### PR DESCRIPTION
- Update virtual methods to use `RelocateVirtual`
- Kept existing flat implementation code behind `REL::Module::IsVR` check
- Removing virtual as the virtual part is now handled `RelocateVirtual`.
  - When keeping the virtual the game crashes with a stacktrace indicating that it is calling the wrong function so I guess it must be non-virtual for the handling to be correct.

**vtable offsets used**  
* [f4sevr_vtable_offsets.md](https://github.com/user-attachments/files/21374938/f4sevr_vtable_offsets.md)
* [commonlib_re_vtable_offsets.md](https://github.com/user-attachments/files/21374939/commonlib_re_vtable_offsets.md)

**Testing:**
1. Build test using all 3 presets (vr, flat, all)
2. Running FRIK mod on F4 VR
3. No runtime testing for flat F4

**Notes**
1. I couldn't find existing usages of `RelocateVirtual` anywhere. Let me know if the implementation is incorrect
2. In `NiNode` the virtual method offset comment doesn't match the order in some cases (example `DetachChild`). I kept the order index but without runtime testing or RE I'm not sure.
3. I don't have a flat F4 setup or mod to test the changes. Any suggestion on how to verify flat is not broken?