### PR TITLE
build: fix build due to unused argument warning in an empty function

### DIFF
--- a/CommonLibF4/include/RE/Bethesda/Actor.h
+++ b/CommonLibF4/include/RE/Bethesda/Actor.h
@@ -999,7 +999,7 @@ namespace RE
 		virtual bool                 DrinkPotion(AlchemyItem* a_potion, std::uint32_t a_stackID);                                                                                                                        // 119
 		virtual bool                 CheckCast(MagicItem* a_spell, bool a_dualCast, MagicSystem::CannotCastReason* a_reason);                                                                                            // 11A
 		virtual void                 CheckTempModifiers() { return; }                                                                                                                                                    // 11B
-		virtual void                 SetLastRiddenMount(ActorHandle) { return; }                                                                                                                                 // 11C
+		virtual void                 SetLastRiddenMount(ActorHandle) { return; }                                                                                                                                         // 11C
 		virtual ActorHandle          QLastRiddenMount() const;                                                                                                                                                           // 11D
 		virtual bool                 CalculateCachedOwnerIsUndead() const;                                                                                                                                               // 11E
 		virtual bool                 CalculateCachedOwnerIsNPC() const;                                                                                                                                                  // 11F

--- a/CommonLibF4/include/RE/Bethesda/Actor.h
+++ b/CommonLibF4/include/RE/Bethesda/Actor.h
@@ -999,7 +999,7 @@ namespace RE
 		virtual bool                 DrinkPotion(AlchemyItem* a_potion, std::uint32_t a_stackID);                                                                                                                        // 119
 		virtual bool                 CheckCast(MagicItem* a_spell, bool a_dualCast, MagicSystem::CannotCastReason* a_reason);                                                                                            // 11A
 		virtual void                 CheckTempModifiers() { return; }                                                                                                                                                    // 11B
-		virtual void                 SetLastRiddenMount(ActorHandle a_mount) { return; }                                                                                                                                 // 11C
+		virtual void                 SetLastRiddenMount(ActorHandle) { return; }                                                                                                                                 // 11C
 		virtual ActorHandle          QLastRiddenMount() const;                                                                                                                                                           // 11D
 		virtual bool                 CalculateCachedOwnerIsUndead() const;                                                                                                                                               // 11E
 		virtual bool                 CalculateCachedOwnerIsNPC() const;                                                                                                                                                  // 11F

--- a/CommonLibF4/include/RE/Bethesda/BSInputEnableManager.h
+++ b/CommonLibF4/include/RE/Bethesda/BSInputEnableManager.h
@@ -41,8 +41,7 @@ namespace RE
 		inline OTHER_EVENT_FLAG operator&(OTHER_EVENT_FLAG lhs, OTHER_EVENT_FLAG rhs)
 		{
 			using U = std::underlying_type_t<OTHER_EVENT_FLAG>;
-			return static_cast<OTHER_EVENT_FLAG>(static_cast<U>(lhs) & static_cast<U>(rhs)
-			);
+			return static_cast<OTHER_EVENT_FLAG>(static_cast<U>(lhs) & static_cast<U>(rhs));
 		}
 
 		inline OTHER_EVENT_FLAG operator~(OTHER_EVENT_FLAG value)

--- a/CommonLibF4/include/RE/Bethesda/BSInputEnableManager.h
+++ b/CommonLibF4/include/RE/Bethesda/BSInputEnableManager.h
@@ -31,6 +31,24 @@ namespace RE
 			kCursor = 1 << 9,
 			kSprinting = 1 << 10,
 		};
+
+		inline OTHER_EVENT_FLAG operator|(OTHER_EVENT_FLAG lhs, OTHER_EVENT_FLAG rhs)
+		{
+			using U = std::underlying_type_t<OTHER_EVENT_FLAG>;
+			return static_cast<OTHER_EVENT_FLAG>(static_cast<U>(lhs) | static_cast<U>(rhs));
+		}
+
+		inline OTHER_EVENT_FLAG operator&(OTHER_EVENT_FLAG lhs, OTHER_EVENT_FLAG rhs)
+		{
+			using U = std::underlying_type_t<OTHER_EVENT_FLAG>;
+			return static_cast<OTHER_EVENT_FLAG>(static_cast<U>(lhs) & static_cast<U>(rhs)
+			);
+		}
+
+		inline OTHER_EVENT_FLAG operator~(OTHER_EVENT_FLAG value)
+		{
+			return static_cast<OTHER_EVENT_FLAG>(~static_cast<std::underlying_type_t<OTHER_EVENT_FLAG>>(value));
+		}
 	}
 
 	using OEFlag = OtherInputEvents::OTHER_EVENT_FLAG;
@@ -102,6 +120,7 @@ namespace RE
 			return func(this, a_layerID, a_userEventFlags, a_enable, a_senderID);
 		}
 
+		// TODO: this doesn't seem to work in VR
 		bool EnableOtherEvent(std::uint32_t a_layerID, OEFlag a_otherEventFlags, bool a_enable, UserEvents::SENDER_ID a_senderID)
 		{
 			using func_t = decltype(&BSInputEnableManager::EnableOtherEvent);
@@ -109,6 +128,7 @@ namespace RE
 			return func(this, a_layerID, a_otherEventFlags, a_enable, a_senderID);
 		}
 
+		// TODO: in VR this affects the other input events instead!
 		void ForceUserEventEnabled(UEFlag a_userEventFlags, bool a_enable)
 		{
 			BSAutoLock locker(cacheLock);
@@ -126,6 +146,17 @@ namespace RE
 				forceOtherInputEventsFlags.set(a_otherEventFlags);
 			} else {
 				forceOtherInputEventsFlags.reset(a_otherEventFlags);
+			}
+		}
+
+		// TODO: in VR this is actually updates the other input events flags and "ForceOtherEventEnabled" doesn't do anything, probably wrong alignment
+		void ForceOtherEventEnabledVR(OEFlag a_otherEventFlags, bool a_enable)
+		{
+			BSAutoLock locker(cacheLock);
+			if (a_enable) {
+				forceEnableInputUserEventsFlags.set(static_cast<UEFlag>(a_otherEventFlags));
+			} else {
+				forceEnableInputUserEventsFlags.reset(static_cast<UEFlag>(a_otherEventFlags));
 			}
 		}
 

--- a/CommonLibF4/include/RE/Bethesda/UserEvents.h
+++ b/CommonLibF4/include/RE/Bethesda/UserEvents.h
@@ -22,6 +22,26 @@ namespace RE
 			kVATS = 1 << 11
 		};
 
+		inline USER_EVENT_FLAG operator|(USER_EVENT_FLAG lhs, USER_EVENT_FLAG rhs)
+		{
+			using U = std::underlying_type_t<USER_EVENT_FLAG>;
+			return static_cast<USER_EVENT_FLAG>(static_cast<U>(lhs) | static_cast<U>(rhs));
+		}
+
+		inline USER_EVENT_FLAG operator&(USER_EVENT_FLAG lhs, USER_EVENT_FLAG rhs)
+		{
+			using U = std::underlying_type_t<USER_EVENT_FLAG>;
+			return static_cast<USER_EVENT_FLAG>(
+				static_cast<U>(lhs) & static_cast<U>(rhs)
+			);
+		}
+
+		inline USER_EVENT_FLAG operator~(USER_EVENT_FLAG value)
+		{
+			using U = std::underlying_type_t<USER_EVENT_FLAG>;
+			return static_cast<USER_EVENT_FLAG>(~static_cast<U>(value));
+		}
+
 		enum class INPUT_CONTEXT_ID
 		{
 			kMainGameplay = 0,

--- a/CommonLibF4/include/RE/Bethesda/UserEvents.h
+++ b/CommonLibF4/include/RE/Bethesda/UserEvents.h
@@ -32,8 +32,7 @@ namespace RE
 		{
 			using U = std::underlying_type_t<USER_EVENT_FLAG>;
 			return static_cast<USER_EVENT_FLAG>(
-				static_cast<U>(lhs) & static_cast<U>(rhs)
-			);
+				static_cast<U>(lhs) & static_cast<U>(rhs));
 		}
 
 		inline USER_EVENT_FLAG operator~(USER_EVENT_FLAG value)


### PR DESCRIPTION
should be green build now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bitwise operators for input and user-event flag types to allow combined flag expressions and negation.
  * Added methods to force enable/disable "other" input events, including a VR-specific variant that affects VR input handling.

* **Refactor**
  * Minor public method signature cleanup (parameter name removed) with no behavioral change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->