### PR TITLE
fix: ctds from papyrus none array

### DIFF
--- a/CommonLibF4/include/RE/Bethesda/BSScriptUtil.h
+++ b/CommonLibF4/include/RE/Bethesda/BSScriptUtil.h
@@ -6,9 +6,9 @@
 #include "RE/Bethesda/GameScript.h"
 #include "RE/Bethesda/TESForms.h"
 // for exception handling
+#include <exception>
 #include "RE/Bethesda/BSScript/TypeInfo.h"
 #include "RE/Bethesda/BSScript/Variable.h"
-#include <exception>
 
 #include "F4SE/Logger.h"
 
@@ -49,9 +49,8 @@ namespace RE::BSScript
 	}
 
 	// Helper function to safely check the variable without object unwinding issues.
-	[[nodiscard]] __forceinline __declspec(noinline) bool IsValidVariable(const Variable& a_var) noexcept
+	[[nodiscard]] inline __declspec(noinline) bool IsValidVariable(const Variable& a_var) noexcept
 	{
-		//F4SE::log::warn("IsValidVariable: Called.");
 		__try {
 			if (a_var.is<std::nullptr_t>()) {
 				return false;
@@ -63,11 +62,10 @@ namespace RE::BSScript
 	}
 
 	// A small helper function with the structured exception handler.
-	[[nodiscard]] __forceinline __declspec(noinline) bool IsValidArray_Impl(const void* a_ptr) noexcept
+	[[nodiscard]] inline __declspec(noinline) bool IsValidArray_Impl(const void* a_ptr) noexcept
 	{
 		__try {
 			const auto in = static_cast<const Array*>(a_ptr);
-			// A null pointer is also an invalid case.
 			if (in == nullptr) {
 				return false;
 			}
@@ -79,13 +77,10 @@ namespace RE::BSScript
 	}
 	// New generic helper function to safely check any Array pointer.
 	template <class T>
-	[[nodiscard]] bool IsValidArray(const Variable& a_var) noexcept
+	[[nodiscard]] inline bool IsValidArray(const Variable& a_var) noexcept
 	{
-		//F4SE::log::warn("IsValidArray: Called.");
-		// Check if it is an array first.
 		if (a_var.is<Array>()) {
 			const auto raw_ptr = get<Array>(a_var);
-			// Then call the structured exception handler in a separate function.
 			return IsValidArray_Impl(raw_ptr.get());
 		} else {
 			return false;
@@ -1065,6 +1060,7 @@ namespace RE::BSScript
 		template <class T>
 		[[nodiscard]] __forceinline T UnpackVariable(const Variable& a_var)
 		{
+
 			// Use our helper function to check with __try __except if the variable can be accessed
 			if (!IsValidVariable(a_var)) {
 				return T{};

--- a/CommonLibF4/include/RE/Bethesda/BSScriptUtil.h
+++ b/CommonLibF4/include/RE/Bethesda/BSScriptUtil.h
@@ -6,9 +6,9 @@
 #include "RE/Bethesda/GameScript.h"
 #include "RE/Bethesda/TESForms.h"
 // for exception handling
-#include <exception>
 #include "RE/Bethesda/BSScript/TypeInfo.h"
 #include "RE/Bethesda/BSScript/Variable.h"
+#include <exception>
 
 #include "F4SE/Logger.h"
 
@@ -1060,7 +1060,6 @@ namespace RE::BSScript
 		template <class T>
 		[[nodiscard]] __forceinline T UnpackVariable(const Variable& a_var)
 		{
-
 			// Use our helper function to check with __try __except if the variable can be accessed
 			if (!IsValidVariable(a_var)) {
 				return T{};

--- a/CommonLibF4/include/RE/Bethesda/BSScriptUtil.h
+++ b/CommonLibF4/include/RE/Bethesda/BSScriptUtil.h
@@ -6,9 +6,9 @@
 #include "RE/Bethesda/GameScript.h"
 #include "RE/Bethesda/TESForms.h"
 // for exception handling
-#include <exception>
 #include "RE/Bethesda/BSScript/TypeInfo.h"
 #include "RE/Bethesda/BSScript/Variable.h"
+#include <exception>
 
 #include "F4SE/Logger.h"
 
@@ -1065,7 +1065,6 @@ namespace RE::BSScript
 		template <class T>
 		[[nodiscard]] __forceinline T UnpackVariable(const Variable& a_var)
 		{
-
 			// Use our helper function to check with __try __except if the variable can be accessed
 			if (!IsValidVariable(a_var)) {
 				return T{};

--- a/CommonLibF4/include/REL/Version.h
+++ b/CommonLibF4/include/REL/Version.h
@@ -1,5 +1,13 @@
 #pragma once
 
+#include <array>
+#include <string>
+#include <string_view>
+#include <stdexcept>
+#include <compare>
+#include <optional>
+#include <iosfwd>
+
 namespace REL
 {
 	class Version
@@ -18,32 +26,6 @@ namespace REL
 		constexpr Version(value_type a_v1, value_type a_v2 = 0, value_type a_v3 = 0, value_type a_v4 = 0) noexcept :
 			_impl{ a_v1, a_v2, a_v3, a_v4 }
 		{}
-
-		explicit constexpr Version(std::string_view a_version)
-		{
-			std::array<value_type, 4> powers{ 1, 1, 1, 1 };
-			std::size_t               position = 0;
-			for (std::size_t i = 0; i < a_version.size(); ++i) {
-				if (a_version[i] == '.') {
-					if (++position == powers.size()) {
-						throw std::invalid_argument("Too many parts in version number.");
-					}
-				} else {
-					powers[position] *= 10;
-				}
-			}
-			position = 0;
-			for (std::size_t i = 0; i < a_version.size(); ++i) {
-				if (a_version[i] == '.') {
-					++position;
-				} else if (a_version[i] < '0' || a_version[i] > '9') {
-					throw std::invalid_argument("Invalid character in version number.");
-				} else {
-					powers[position] /= 10;
-					_impl[position] += static_cast<value_type>((a_version[i] - '0') * powers[position]);
-				}
-			}
-		}
 
 		[[nodiscard]] constexpr reference       operator[](std::size_t a_idx) noexcept { return _impl[a_idx]; }
 		[[nodiscard]] constexpr const_reference operator[](std::size_t a_idx) const noexcept { return _impl[a_idx]; }
@@ -77,7 +59,7 @@ namespace REL
 		[[nodiscard]] constexpr value_type patch() const noexcept { return _impl[2]; }
 		[[nodiscard]] constexpr value_type build() const noexcept { return _impl[3]; }
 
-		[[nodiscard]] constexpr std::string string(const std::string_view a_separator = "."sv) const
+		[[nodiscard]] std::string string(const std::string_view a_separator = "."sv) const
 		{
 			std::string result;
 			for (auto&& ver : _impl) {
@@ -88,7 +70,7 @@ namespace REL
 			return result;
 		}
 
-		[[nodiscard]] constexpr std::wstring wstring(const std::wstring_view a_separator = L"."sv) const
+		[[nodiscard]] std::wstring wstring(const std::wstring_view a_separator = L"."sv) const
 		{
 			std::wstring result;
 			for (auto&& ver : _impl) {
@@ -127,24 +109,33 @@ namespace REL
 	[[nodiscard]] std::optional<Version> GetFileVersion(std::wstring_view a_filename);
 }
 
+#ifndef FMT_VERSION
+#include <fmt/core.h>
+#endif
+
 template <class CharT>
-struct std::formatter<REL::Version, CharT> : formatter<std::string, CharT>
+struct std::formatter<REL::Version, CharT> : std::formatter<std::string, CharT>
 {
 	template <class FormatContext>
 	constexpr auto format(const REL::Version& a_version, FormatContext& a_ctx) const
 	{
-		return formatter<std::string, CharT>::format(a_version.string(), a_ctx);
+		return std::formatter<std::string, CharT>::format(a_version.string(), a_ctx);
 	}
 };
 
 #ifdef FMT_VERSION
 template <class CharT>
-struct fmt::formatter<REL::Version, CharT> : formatter<std::string, CharT>
+struct fmt::formatter<REL::Version, CharT>
 {
-	template <class FormatContext>
-	auto format(const REL::Version& a_version, FormatContext& a_ctx)
+	template <class ParseContext>
+	constexpr auto parse(ParseContext& a_ctx)
 	{
-		return formatter<std::string, CharT>::format(a_version.string(), a_ctx);
+		return a_ctx.begin();
+	}
+	template <class FormatContext>
+	auto format(const REL::Version& a_version, FormatContext& a_ctx) const
+	{
+		return fmt::format_to(a_ctx.out(), "{}", a_version.string());
 	}
 };
 #endif


### PR DESCRIPTION
This prevents the game from crashing before the data reaches the Plugin function, if an expected array is passed as None from Papyrus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents crashes when unpacking script arrays by validating array data before use.
  * Safely returns default values for invalid or corrupted arrays instead of triggering errors.
  * Improves overall stability when encountering malformed inputs during scripting operations.
  * No impact to behavior for non-array types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->