### PR TITLE
feat(VR): Add Buffout x Daytripper integration

### DIFF
--- a/CommonLibF4/include/RE/Bethesda/TESDataHandler.h
+++ b/CommonLibF4/include/RE/Bethesda/TESDataHandler.h
@@ -103,6 +103,24 @@ namespace RE
 						TESDataHandler::VRcompiledFileCollection = const_cast<RE::TESFileCollection*>(GetCompiledFileCollection());
 					}
 				}
+				// Construct compiledFileCollection for non-falloutvresl envirnment
+				else if (*singleton) {
+					static RE::TESFileCollection vrCompiledFileCollection;
+					vrCompiledFileCollection.files.clear();
+					vrCompiledFileCollection.smallFiles.clear();
+					for (auto& file : (*singleton)->files) {
+						if (!file)
+							continue;
+						if (0xFF == file->compileIndex)  // is inactive file
+							continue;
+
+						if (file->IsLight())
+							vrCompiledFileCollection.smallFiles.push_back(file);
+						else
+							vrCompiledFileCollection.files.push_back(file);
+					}
+					VRcompiledFileCollection = &vrCompiledFileCollection;
+				}
 			}
 			return *singleton;
 		}


### PR DESCRIPTION
This patch helps Buffout crash logger to list up ESL plugins in VR.
Daytripper is in mind, but any other ESL enabler should work fine.
VRcompiledFileCollection is built from pDataHandler->files in runtime for non-falloutvresl environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file collection system to ensure proper initialization in VR environments when external data sources are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->