### PR TITLE
feat: add signatures for creating BSScaleformExternalTexture

### DIFF
--- a/CommonLibF4/include/RE/Bethesda/BSGraphics.h
+++ b/CommonLibF4/include/RE/Bethesda/BSGraphics.h
@@ -41,7 +41,51 @@ namespace RE
 		enum class Format;
 		enum class TextureAddressMode;
 
-		class Texture;
+		struct TextureHeader
+		{
+		public:
+			// members
+			std::uint16_t height = 0;    // 00
+			std::uint16_t width = 0;     // 02
+			std::uint8_t  mipCount = 0;  // 04
+			std::uint8_t  format = 0;    // 05
+			std::uint8_t  flags = 0;     // 06
+			std::uint8_t  tilemode = 0;  // 07
+		};
+		static_assert(sizeof(TextureHeader) == 0x8);
+
+		class Texture
+		{
+		public:
+			REX::W32::ID3D11ShaderResourceView* srv;              // 00
+			REX::W32::ID3D11Texture2D*          texture;          // 08
+			void*								unk10;            // 10
+			void*								unk18;            // 18
+			void*								unk20;            // 20
+			TextureHeader						header;           // 28
+			std::uint32_t						unk30;            // 30
+			std::uint32_t						refCount;         // 34
+			std::uint8_t						unk38[4];         // 38
+			std::uint8_t						currentMipLevel;  // 3C
+			std::uint8_t						targetMipLevel;   // 3D
+			std::uint8_t						flags2;           // 3E
+			std::uint8_t						flags3;           // 3F
+		};
+		static_assert(sizeof(Texture) == 0x40);
+
+		inline Texture* CreateTexture(TextureHeader& header, bool sRGB)
+		{
+			using func_t = Texture* (*)(TextureHeader& header, bool sRGB);
+			REL::Relocation<func_t> func{ REL::ID(270276) };
+			return func(header, sRGB);
+		}
+
+		inline void LoadTextureData(Texture* texture, char* data, std::uint32_t dataSize, std::uint32_t mipLevel)
+		{
+			using func_t = decltype(&BSGraphics::LoadTextureData);
+			REL::Relocation<func_t> func{ REL::ID(415185) };
+			return func(texture, data, dataSize, mipLevel);
+		}
 
 		enum class MultiSampleLevel
 		{
@@ -96,19 +140,6 @@ namespace RE
 		struct IndexBuffer : public Buffer
 		{};
 		static_assert(sizeof(IndexBuffer) == 0x50);
-
-		struct TextureHeader
-		{
-		public:
-			// members
-			std::uint16_t height = 0;    // 0
-			std::uint16_t width = 0;     // 2
-			std::uint8_t  mipCount = 0;  // 3
-			std::uint8_t  format = 0;    // 5
-			std::uint8_t  flags = 0;     // 6
-			std::uint8_t  tilemode = 0;  // 7
-		};
-		static_assert(sizeof(TextureHeader) == 0x8);
 
 		class ConstantGroup
 		{

--- a/CommonLibF4/include/RE/Bethesda/BSGraphics.h
+++ b/CommonLibF4/include/RE/Bethesda/BSGraphics.h
@@ -59,17 +59,17 @@ namespace RE
 		public:
 			REX::W32::ID3D11ShaderResourceView* srv;              // 00
 			REX::W32::ID3D11Texture2D*          texture;          // 08
-			void*								unk10;            // 10
-			void*								unk18;            // 18
-			void*								unk20;            // 20
-			TextureHeader						header;           // 28
-			std::uint32_t						unk30;            // 30
-			std::uint32_t						refCount;         // 34
-			std::uint8_t						unk38[4];         // 38
-			std::uint8_t						currentMipLevel;  // 3C
-			std::uint8_t						targetMipLevel;   // 3D
-			std::uint8_t						flags2;           // 3E
-			std::uint8_t						flags3;           // 3F
+			void*                               unk10;            // 10
+			void*                               unk18;            // 18
+			void*                               unk20;            // 20
+			TextureHeader                       header;           // 28
+			std::uint32_t                       unk30;            // 30
+			std::uint32_t                       refCount;         // 34
+			std::uint8_t                        unk38[4];         // 38
+			std::uint8_t                        currentMipLevel;  // 3C
+			std::uint8_t                        targetMipLevel;   // 3D
+			std::uint8_t                        flags2;           // 3E
+			std::uint8_t                        flags3;           // 3F
 		};
 		static_assert(sizeof(Texture) == 0x40);
 

--- a/CommonLibF4/include/RE/Bethesda/BSGraphics.h
+++ b/CommonLibF4/include/RE/Bethesda/BSGraphics.h
@@ -76,14 +76,14 @@ namespace RE
 		inline Texture* CreateTexture(TextureHeader& header, bool sRGB)
 		{
 			using func_t = Texture* (*)(TextureHeader& header, bool sRGB);
-			REL::Relocation<func_t> func{ REL::ID(270276) };
+			static REL::Relocation<func_t> func{ REL::ID(270276) };
 			return func(header, sRGB);
 		}
 
 		inline void LoadTextureData(Texture* texture, char* data, std::uint32_t dataSize, std::uint32_t mipLevel)
 		{
 			using func_t = decltype(&BSGraphics::LoadTextureData);
-			REL::Relocation<func_t> func{ REL::ID(415185) };
+			static REL::Relocation<func_t> func{ REL::ID(415185) };
 			return func(texture, data, dataSize, mipLevel);
 		}
 

--- a/CommonLibF4/include/RE/Bethesda/IMenu.h
+++ b/CommonLibF4/include/RE/Bethesda/IMenu.h
@@ -1275,14 +1275,14 @@ namespace RE
 		void SetTexture(NiTexture* niTexture)
 		{
 			using func_t = decltype(&BSScaleformExternalTexture::SetTexture);
-			REL::Relocation<func_t> func{ REL::ID(119731) };
+			static REL::Relocation<func_t> func{ REL::ID(119731) };
 			return func(this, niTexture);
 		}
 
 		void ReleaseTexture()
 		{
 			using func_t = decltype(&BSScaleformExternalTexture::ReleaseTexture);
-			REL::Relocation<func_t> func{ REL::ID(651971) };
+			static REL::Relocation<func_t> func{ REL::ID(651971) };
 			return func(this);
 		}
 

--- a/CommonLibF4/include/RE/Bethesda/IMenu.h
+++ b/CommonLibF4/include/RE/Bethesda/IMenu.h
@@ -1272,6 +1272,20 @@ namespace RE
 	class BSScaleformExternalTexture
 	{
 	public:
+		void SetTexture(NiTexture* niTexture)
+		{
+			using func_t = decltype(&BSScaleformExternalTexture::SetTexture);
+			REL::Relocation<func_t> func{ REL::ID(119731) };
+			return func(this, niTexture);
+		}
+
+		void ReleaseTexture()
+		{
+			using func_t = decltype(&BSScaleformExternalTexture::ReleaseTexture);
+			REL::Relocation<func_t> func{ REL::ID(651971) };
+			return func(this);
+		}
+
 		// members
 		NiPointer<NiTexture> gamebryoTexture;  // 00
 		std::uint32_t        renderTarget;     // 08

--- a/CommonLibF4/include/RE/NetImmerse/NiTexture.h
+++ b/CommonLibF4/include/RE/NetImmerse/NiTexture.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "RE/Bethesda/BSFixedString.h"
+#include "RE/Bethesda/BSResourceNiBinaryStream.h"
 #include "RE/Bethesda/BSTSmartPointer.h"
 #include "RE/NetImmerse/NiObject.h"
 
@@ -29,6 +30,27 @@ namespace RE
 		static constexpr auto RTTI{ RTTI::NiTexture };
 		static constexpr auto VTABLE{ VTABLE::NiTexture };
 		static constexpr auto Ni_RTTI{ Ni_RTTI::NiTexture };
+
+		static NiTexture* Create(RE::BSFixedString& texturePath, bool isSRGB, bool allowDegrade)
+		{
+			using func_t = NiTexture* (*)(RE::BSFixedString& texturePath, bool isSRGB, bool allowDegrade);
+			REL::Relocation<func_t>   func{ REL::ID(1071950) };
+			return func(texturePath, isSRGB, allowDegrade);
+		}
+
+		static NiTexture* Create(RE::BSResourceNiBinaryStream* stream, const char* texturePath, bool isDDX, bool isSRGB, bool allowDegrade)
+		{
+			using func_t = NiTexture* (*)(RE::BSResourceNiBinaryStream* stream, const char* texturePath, bool isDDX, bool isSRGB, bool allowDegrade);
+			REL::Relocation<func_t>   func{ REL::ID(964969) };
+			return func(stream, texturePath, isDDX, isSRGB, allowDegrade);
+		}
+
+		static NiTexture* Create(BSTSmartPointer<RE::BSResource::Stream>& stream, const char* texturePath, bool isDDX, bool isSRGB, bool allowDegrade)
+		{
+			using func_t = NiTexture* (*)(BSTSmartPointer<RE::BSResource::Stream>& stream, const char* texturePath, bool isDDX, bool isSRGB, bool allowDegrade);
+			REL::Relocation<func_t>   func{ REL::ID(685580) };
+			return func(stream, texturePath, isDDX, isSRGB, allowDegrade);
+		}
 
 		// add
 		virtual BSTextureArray::Texture* IsBSTextureArray() { return nullptr; }  // 28

--- a/CommonLibF4/include/RE/NetImmerse/NiTexture.h
+++ b/CommonLibF4/include/RE/NetImmerse/NiTexture.h
@@ -34,21 +34,21 @@ namespace RE
 		static NiTexture* Create(RE::BSFixedString& texturePath, bool isSRGB, bool allowDegrade)
 		{
 			using func_t = NiTexture* (*)(RE::BSFixedString& texturePath, bool isSRGB, bool allowDegrade);
-			REL::Relocation<func_t>   func{ REL::ID(1071950) };
+			REL::Relocation<func_t> func{ REL::ID(1071950) };
 			return func(texturePath, isSRGB, allowDegrade);
 		}
 
 		static NiTexture* Create(RE::BSResourceNiBinaryStream* stream, const char* texturePath, bool isDDX, bool isSRGB, bool allowDegrade)
 		{
 			using func_t = NiTexture* (*)(RE::BSResourceNiBinaryStream* stream, const char* texturePath, bool isDDX, bool isSRGB, bool allowDegrade);
-			REL::Relocation<func_t>   func{ REL::ID(964969) };
+			REL::Relocation<func_t> func{ REL::ID(964969) };
 			return func(stream, texturePath, isDDX, isSRGB, allowDegrade);
 		}
 
 		static NiTexture* Create(BSTSmartPointer<RE::BSResource::Stream>& stream, const char* texturePath, bool isDDX, bool isSRGB, bool allowDegrade)
 		{
 			using func_t = NiTexture* (*)(BSTSmartPointer<RE::BSResource::Stream>& stream, const char* texturePath, bool isDDX, bool isSRGB, bool allowDegrade);
-			REL::Relocation<func_t>   func{ REL::ID(685580) };
+			REL::Relocation<func_t> func{ REL::ID(685580) };
 			return func(stream, texturePath, isDDX, isSRGB, allowDegrade);
 		}
 

--- a/CommonLibF4/include/RE/NetImmerse/NiTexture.h
+++ b/CommonLibF4/include/RE/NetImmerse/NiTexture.h
@@ -34,21 +34,21 @@ namespace RE
 		static NiTexture* Create(RE::BSFixedString& texturePath, bool isSRGB, bool allowDegrade)
 		{
 			using func_t = NiTexture* (*)(RE::BSFixedString& texturePath, bool isSRGB, bool allowDegrade);
-			REL::Relocation<func_t> func{ REL::ID(1071950) };
+			static REL::Relocation<func_t> func{ REL::ID(1071950) };
 			return func(texturePath, isSRGB, allowDegrade);
 		}
 
 		static NiTexture* Create(RE::BSResourceNiBinaryStream* stream, const char* texturePath, bool isDDX, bool isSRGB, bool allowDegrade)
 		{
 			using func_t = NiTexture* (*)(RE::BSResourceNiBinaryStream* stream, const char* texturePath, bool isDDX, bool isSRGB, bool allowDegrade);
-			REL::Relocation<func_t> func{ REL::ID(964969) };
+			static REL::Relocation<func_t> func{ REL::ID(964969) };
 			return func(stream, texturePath, isDDX, isSRGB, allowDegrade);
 		}
 
 		static NiTexture* Create(BSTSmartPointer<RE::BSResource::Stream>& stream, const char* texturePath, bool isDDX, bool isSRGB, bool allowDegrade)
 		{
 			using func_t = NiTexture* (*)(BSTSmartPointer<RE::BSResource::Stream>& stream, const char* texturePath, bool isDDX, bool isSRGB, bool allowDegrade);
-			REL::Relocation<func_t> func{ REL::ID(685580) };
+			static REL::Relocation<func_t> func{ REL::ID(685580) };
 			return func(stream, texturePath, isDDX, isSRGB, allowDegrade);
 		}
 

--- a/CommonLibF4/include/REL/Version.h
+++ b/CommonLibF4/include/REL/Version.h
@@ -142,7 +142,7 @@ template <class CharT>
 struct fmt::formatter<REL::Version, CharT> : formatter<std::string, CharT>
 {
 	template <class FormatContext>
-	auto format(const REL::Version& a_version, FormatContext& a_ctx)
+	auto format(const REL::Version& a_version, FormatContext& a_ctx) const
 	{
 		return formatter<std::string, CharT>::format(a_version.string(), a_ctx);
 	}


### PR DESCRIPTION
Adding signatures to create BSScaleformExternalTexture

Context: MediaFramework uses texture swaps on a BSGraphics::Texture to allow "video playback" on textures. To have a Menu which uses a BSGraphics::Texture it needs to be wrapped by a NiTexture, then wrapped by a BSScaleformExternalTexture before it can be interpreted by a scaleform object. Somewhat similar path used by the pipboy map.

BSScaleformExternalTexture
-Added set and release texture

NiTexture
-Added a few NiTexture create signatures
-Worth noting NiTextures seem to be managed by the engine, trying to control the lifetime is problematic
-Could only confirm functionality of static NiTexture* Create(BSTSmartPointer<RE::BSResource::Stream>& stream, const char* texturePath, bool isDDX, bool isSRGB, bool allowDegrade), I never saw calls to the other functions in Cheat Engine
 
Texture 
-Added partial structure of texture struct
-Added create texture
-Added LoadTextureData, replace the pixel data
-TextureHeader comment typo fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive texture creation and loading options (file- and stream-based) for richer asset initialization.
  * Added runtime texture assignment and explicit release methods for UI rendering components.
* **Chores**
  * Minor API signature refinement for formatting utilities (no behavioral change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->