### PR TITLE
fix: replace deprecated std::aligned_storage_t (C++23 STL4034)

### DIFF
--- a/CommonLibF4/include/RE/msvc/functional.h
+++ b/CommonLibF4/include/RE/msvc/functional.h
@@ -39,7 +39,8 @@ namespace RE::msvc
 
 		[[nodiscard]] bool good() const noexcept { return _fn != nullptr; }
 
-		std::aligned_storage_t<3 * sizeof(void*), alignof(long double)> _storage;  // 00
-		proxy_t*                                                        _fn;       // 18
+		// std::aligned_storage[_t] is deprecated in C++23; use the recommended alignas byte buffer instead.
+		alignas(long double) std::byte _storage[3 * sizeof(void*)];  // 00
+		proxy_t* _fn;                                                // 18
 	};
 }


### PR DESCRIPTION
## Problem

`std::aligned_storage` / `std::aligned_storage_t` are deprecated in C++23. The updated MSVC STL (rolling out on GitHub's `windows-latest` → `windows-2025-vs2026` runners) now emits **C4996 / STL4034** for the `_storage` member in `RE::msvc::function` (`RE/msvc/functional.h:42`).

This breaks every downstream consumer that compiles CommonLibF4 with warnings-as-errors. For example, Buffout4 sets `/WX` globally and its release build now fails:

```
RE\msvc\functional.h(42,8): error C2220: the following warning is treated as an error
warning C4996: 'std::aligned_storage_t': warning STL4034: std::aligned_storage and
std::aligned_storage_t are deprecated in C++23.
```

## Fix

Replace `std::aligned_storage_t<3 * sizeof(void*), alignof(long double)>` with the MSVC-recommended `alignas(long double) std::byte _storage[3 * sizeof(void*)]`.

The storage is byte-identical: **24 bytes, aligned to `alignof(long double)` (8)**, with `_fn` still at offset `0x18`. The ABI mirror of `std::_Func_class` is unchanged. `std::byte` is already provided via the library PCH (`<cstddef>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)