### PR TITLE
ci: enable vcpkg binary caching in main_ci

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -8,7 +8,10 @@ on:
   workflow_dispatch:
 
 env:
-  VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg-cache
+  # Persist vcpkg-built dependency binaries in the GitHub Actions cache so the matrix
+  # configs (and future runs) restore prebuilt .libs instead of recompiling them. The
+  # previous workspace-local cache dir was wiped each run, so it never helped.
+  VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
 jobs:
   windows:
@@ -42,6 +45,15 @@ jobs:
         uses: friendlyanon/setup-vcpkg@v1
         with:
           committish: 943c5ef1c8f6b5e6ced092b242c8299caae2ff01
+
+      # x-gha reads the Actions cache endpoint from these two variables, which GitHub
+      # only exposes to the github-script runtime — re-export them so vcpkg sees them.
+      - name: Enable vcpkg GitHub Actions binary cache
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Build
         uses: lukka/run-cmake@v10.0


### PR DESCRIPTION
## Why

The `windows` build matrix recompiles vcpkg dependencies from source on every run. `VCPKG_DEFAULT_BINARY_CACHE` points at `${{ github.workspace }}/vcpkg-cache` — a **workspace-local dir that's wiped each run**, so it never actually persisted anything.

## What

Switch to the **GitHub Actions cache** as a vcpkg binary source:
- `VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"` (replaces the dead local-dir cache).
- A `github-script` step re-exports `ACTIONS_CACHE_URL` / `ACTIONS_RUNTIME_TOKEN` (GitHub only exposes these to the github-script runtime; vcpkg's `x-gha` provider needs them).

Now dependency `.libs` are restored across runs and matrix configs instead of recompiled. Validated locally on a sibling repo: a warm cache turns a dep build into a ~ms restore.

Part of a stack-wide sweep (CommonLibVR, CrashLoggerSSE, Buffout4, EngineFixesSkyrim64 already done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)