### PR TITLE
fix(havok): hkVector4f::GetNormalized dangling ref

### DIFF
--- a/CommonLibF4/include/RE/Havok/hkVector4.h
+++ b/CommonLibF4/include/RE/Havok/hkVector4.h
@@ -133,7 +133,7 @@ namespace RE
 			this->z /= l;
 			return *this;
 		}
-		hkVector4f& GetNormalized()
+		hkVector4f GetNormalized()
 		{
 			hkVector4f norm = *this;
 			norm.Normalize();


### PR DESCRIPTION
## Summary
- `hkVector4f::GetNormalized()` built a local `norm`, normalized it, then returned it as `hkVector4f&` - a reference to a variable that goes out of scope on return. Always a dangling-reference bug.
- Older/looser MSVC toolsets silently accepted the binding; the newer VS 18 toolset (14.51.x) correctly rejects it with `C2440: cannot convert from 'hkVector4f' to 'hkVector4f &'`, which is what's currently blocking Buffout4's CI (alandtse/Buffout4#44).
- Fix: return by value. Matches the function's actual semantics - it builds a new normalized copy, unlike `Normalize()` which mutates `*this` and correctly returns `*this` by reference.
- No other call sites in the tree depend on reference semantics from this function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qnfj2DML4RGxFb3MaRyzb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected normalized vector results to be returned safely as independent values, preventing potential reference-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->